### PR TITLE
fix: resolve pi binary as .cmd and spawn via cmd.exe on Windows

### DIFF
--- a/bin/little-coder.mjs
+++ b/bin/little-coder.mjs
@@ -29,7 +29,9 @@ const here = dirname(fileURLToPath(import.meta.url));
 const pkgRoot = resolve(here, "..");
 
 // ---- 3. Resolve the bundled pi binary ----
-const piBin = join(pkgRoot, "node_modules", ".bin", "pi");
+const isWindows = process.platform === "win32";
+const piBinBase = join(pkgRoot, "node_modules", ".bin", "pi");
+const piBin = isWindows && existsSync(`${piBinBase}.cmd`) ? `${piBinBase}.cmd` : piBinBase;
 if (!existsSync(piBin)) {
   console.error(
     `little-coder: cannot find pi at ${piBin}.\n` +
@@ -86,7 +88,11 @@ const piArgs = [
 ];
 
 // ---- 7. Spawn pi in the user's cwd ----
-const child = spawn(piBin, piArgs, {
+const [spawnCmd, spawnArgs] = isWindows
+  ? ["cmd.exe", ["/c", piBin, ...piArgs]]
+  : [piBin, piArgs];
+
+const child = spawn(spawnCmd, spawnArgs, {
   stdio: "inherit",
   cwd: process.cwd(),
   env: process.env,


### PR DESCRIPTION
Fixes the Windows launch failure where `spawn()` couldn't execute the "pi.cmd" shim.
Tested on Windows 11.

Closes #17