### PR TITLE
Fix Windows user models config lookup

### DIFF
--- a/.pi/extensions/llama-cpp-provider/config.test.ts
+++ b/.pi/extensions/llama-cpp-provider/config.test.ts
@@ -37,10 +37,13 @@ describe("resolveOverridePath", () => {
     expect(resolveOverridePath({ LITTLE_CODER_MODELS_FILE: "/explicit.json", HOME: "/h" })).toBe("/explicit.json");
   });
   it("falls back to XDG_CONFIG_HOME", () => {
-    expect(resolveOverridePath({ XDG_CONFIG_HOME: "/xdg", HOME: "/h" })).toBe("/xdg/little-coder/models.json");
+    expect(resolveOverridePath({ XDG_CONFIG_HOME: "/xdg", HOME: "/h" })).toBe(join("/xdg", "little-coder", "models.json"),);
   });
   it("falls back to HOME/.config", () => {
-    expect(resolveOverridePath({ HOME: "/h" })).toBe("/h/.config/little-coder/models.json");
+    expect(resolveOverridePath({ HOME: "/h" })).toBe(join("/h", ".config", "little-coder", "models.json"),);
+  });
+  it("falls back to USERPROFILE/.config when HOME is absent", () => {
+    expect(resolveOverridePath({ USERPROFILE: "/profile" })).toBe(join("/profile", ".config", "little-coder", "models.json"),);
   });
   it("returns undefined when neither is set", () => {
     expect(resolveOverridePath({})).toBeUndefined();

--- a/.pi/extensions/llama-cpp-provider/config.ts
+++ b/.pi/extensions/llama-cpp-provider/config.ts
@@ -58,7 +58,8 @@ export function resolveOverridePath(env: NodeJS.ProcessEnv = process.env): strin
   if (env.LITTLE_CODER_MODELS_FILE) return env.LITTLE_CODER_MODELS_FILE;
   const xdg = env.XDG_CONFIG_HOME;
   if (xdg) return join(xdg, "little-coder", "models.json");
-  if (env.HOME) return join(env.HOME, ".config", "little-coder", "models.json");
+  const home = env.HOME || env.USERPROFILE;
+  if (home) return join(home, ".config", "little-coder", "models.json");
   return undefined;
 }
 


### PR DESCRIPTION
On Windows, HOME is not guaranteed to be set while USERPROFILE is available. In that case, the documented fallback path ~/.config/little-coder/models.json was skipped, so user-defined models were not registered.

This updates resolveOverridePath() to fall back to USERPROFILE when HOME is absent, and makes the path resolution tests platform-neutral.