### PR TITLE
fix: Windows npm auto-update failure + --update flag

### DIFF
--- a/bin/little-coder.mjs
+++ b/bin/little-coder.mjs
@@ -135,7 +135,8 @@ try {
   // ignore — update-check just won't fire if we can't read the version
 }
 if (!isSubagent) {
-  const exitAfterCheck = await checkForUpdate(currentVersion);
+  const forceUpdate = process.argv.includes("--update");
+  const exitAfterCheck = await checkForUpdate(currentVersion, { force: forceUpdate });
   if (exitAfterCheck) {
     // Successful update happened; user needs to re-run the new binary.
     process.exit(0);
@@ -148,7 +149,9 @@ if (!isSubagent) {
 // --system-prompt    : load <pkgRoot>/AGENTS.md regardless of cwd
 //
 // Strip our own flags before forwarding to pi so it doesn't reject them.
-const userArgs = process.argv.slice(2).filter((a) => a !== "--no-update-check");
+const userArgs = process.argv.slice(2).filter(
+  (a) => a !== "--no-update-check" && a !== "--update",
+);
 const agentsMd = join(pkgRoot, "AGENTS.md");
 
 // Default the thinking level to "medium" for interactive sessions (pi's own

--- a/bin/update-check.mjs
+++ b/bin/update-check.mjs
@@ -123,17 +123,28 @@ function promptYesNo(question) {
 // Returns `true` if the launcher should NOT proceed to spawn pi (because we
 // updated and exited / the user opted out and we should re-run).  Returns
 // `false` to let the launcher continue.
+//
+// opts.force — bypass the 12h cache and always fetch the latest version from
+//   the registry. Used when the user explicitly passes `--update`. If already
+//   at the latest version, prints a short "up to date" notice instead of
+//   silently returning.
 export async function checkForUpdate(currentVersion, opts = {}) {
   const skip = opts.skip ?? shouldSkip();
   if (skip === true) return false;
 
-  let latest = readCache()?.latest;
+  const force = opts.force ?? false;
+  let latest = (!force && readCache()?.latest) || null;
   if (!latest) {
     latest = await fetchLatest();
     if (latest) writeCache(latest);
   }
   if (!latest) return false;
-  if (compareSemver(latest, currentVersion) <= 0) return false;
+  if (compareSemver(latest, currentVersion) <= 0) {
+    if (force) {
+      process.stderr.write(`\n   ✓ little-coder is already up to date (v${currentVersion}).\n\n`);
+    }
+    return false;
+  }
 
   const headline =
     `\n📦 little-coder v${latest} is available (you have v${currentVersion}).`;
@@ -151,8 +162,12 @@ export async function checkForUpdate(currentVersion, opts = {}) {
   }
 
   process.stderr.write(`\n   Running: npm install -g little-coder@${latest}\n\n`);
+  // shell: true is required on Windows where `npm` resolves to `npm.cmd` (a
+  // batch file shim). Without it, spawnSync cannot find the executable and
+  // returns { status: null, error: { code: "ENOENT" } } before npm ever runs.
   const result = spawnSync("npm", ["install", "-g", `little-coder@${latest}`], {
     stdio: "inherit",
+    shell: true,
   });
   if (result.status === 0) {
     process.stderr.write(
@@ -160,8 +175,11 @@ export async function checkForUpdate(currentVersion, opts = {}) {
     );
     return true;
   }
+  const exitDesc = result.error
+    ? `could not launch npm (${result.error.code ?? result.error.message})`
+    : `npm exit ${result.status}`;
   process.stderr.write(
-    `\n   ✗ Update failed (npm exit ${result.status}). Continuing with v${currentVersion}.\n\n`,
+    `\n   ✗ Update failed (${exitDesc}). Continuing with v${currentVersion}.\n\n`,
   );
   return false;
 }

--- a/bin/update-check.mjs
+++ b/bin/update-check.mjs
@@ -162,13 +162,14 @@ export async function checkForUpdate(currentVersion, opts = {}) {
   }
 
   process.stderr.write(`\n   Running: npm install -g little-coder@${latest}\n\n`);
-  // shell: true is required on Windows where `npm` resolves to `npm.cmd` (a
-  // batch file shim). Without it, spawnSync cannot find the executable and
-  // returns { status: null, error: { code: "ENOENT" } } before npm ever runs.
-  const result = spawnSync("npm", ["install", "-g", `little-coder@${latest}`], {
-    stdio: "inherit",
-    shell: true,
-  });
+  // On Windows `npm` resolves to `npm.cmd`, a batch-file shim that Node's
+  // spawnSync cannot execute without shell:true. However, shell:true with
+  // array args triggers DEP0190 on Node 24+. Instead, invoke cmd.exe directly
+  // via COMSPEC — it resolves `npm` to `npm.cmd` itself, no shell:true needed.
+  const npmArgs = ["install", "-g", `little-coder@${latest}`];
+  const result = process.platform === "win32"
+    ? spawnSync(process.env.COMSPEC || "cmd.exe", ["/c", "npm", ...npmArgs], { stdio: "inherit" })
+    : spawnSync("npm", npmArgs, { stdio: "inherit" });
   if (result.status === 0) {
     process.stderr.write(
       `\n   ✓ Updated to v${latest}. Re-run \`little-coder\` to use the new version.\n\n`,

--- a/bin/update-check.test.mjs
+++ b/bin/update-check.test.mjs
@@ -161,4 +161,12 @@ describe("shouldSkip", () => {
   it("returns notice-only on non-TTY pipelines", () => {
     expect(shouldSkip([], noEnv, pipeStdout())).toBe("notice-only");
   });
+
+  it("does not skip for --update (it forces the check, not skips it)", () => {
+    expect(shouldSkip(["--update"], noEnv, ttyStdout())).toBe(false);
+  });
+
+  it("notice-only still applies with --update on non-TTY", () => {
+    expect(shouldSkip(["--update"], noEnv, pipeStdout())).toBe("notice-only");
+  });
 });


### PR DESCRIPTION
## Problem

On Windows, `npm` is a batch-file shim (`npm.cmd`). `spawnSync('npm', ...)` without `shell: true` cannot locate it and returns `{ status: null, error: { code: 'ENOENT' } }` before npm ever runs — producing the confusing:

```
✗ Update failed (npm exit null). Continuing with v1.9.x.
```

The `null` exit code is the tell that npm never launched. Reproduced on Node v24 / npm v11 / Windows 11.

Additionally, passing `little-coder --update` forwarded `--update` to the underlying pi runtime, which rejected it with `Error: Unknown option: --update`.

## Changes

**`bin/update-check.mjs`**
- On Windows, invoke `npm` via `COMSPEC /c npm` instead of using `shell: true`. Both fix the ENOENT, but `shell: true` triggers a `DEP0190` deprecation warning on Node 24+; the COMSPEC approach does not.
- Improve the failure message: when the spawn itself fails (`result.error` is set), surface `result.error.code` (e.g. `ENOENT`) instead of `result.status` (which is `null` and meaningless).
- Add `opts.force` to `checkForUpdate`: bypasses the 12h cache and always fetches fresh from the registry. If already up to date, prints a brief "already up to date" notice.

**`bin/little-coder.mjs`**
- Detect `--update` in argv, pass `force: true` to `checkForUpdate`, and strip the flag before forwarding argv to pi. `little-coder --update` is now a recognized command.

**`bin/update-check.test.mjs`**
- Two new tests documenting that `--update` does not cause `shouldSkip` to return `true` (it forces the check, not skips it).

## Verification

Verified on Node v24 / npm v11 / Windows 11:

```
OLD (no shell)   status: null | error: ENOENT     ← original bug
NEW (COMSPEC/c)  status: 0   | stdout: 11.6.2     ← fix, no DEP0190
```

## Pre-existing test failures on Windows

Two `cachePath` tests were already failing before this PR (hardcoded POSIX path separators). Unrelated to this change.

## Test plan

- [ ] On Windows: `little-coder` now triggers npm via COMSPEC and updates successfully, no DEP0190 warning
- [ ] On Windows: `little-coder --update` forces a fresh registry check without "Unknown option" error
- [ ] On macOS/Linux: behaviour unchanged (POSIX branch uses plain `spawnSync('npm', ...)`)
- [ ] `npx vitest run bin/update-check.test.mjs` — 21 pass (2 pre-existing Windows path failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)