### PR TITLE
feat: add pi package publishing to release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,24 +5,24 @@ name: Publish to npm
 # version, so a typo in either place is caught before anything reaches npm.
 on:
   push:
-    tags: ['v[0-9]*']
+    tags: ["v[0-9]*"]
 
 jobs:
   publish:
     name: Publish on tag
     runs-on: ubuntu-latest
     permissions:
-      contents: write   # required to create the GitHub Release
-      id-token: write   # required for npm provenance via GitHub OIDC
+      contents: write # required to create the GitHub Release
+      id-token: write # required for npm provenance via GitHub OIDC
     steps:
       - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v5
         with:
           # Must match package.json#engines.node (>= 22.19.0); pi 0.75+ requires it.
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
 
       - name: Verify tag matches package.json version
         run: |
@@ -107,9 +107,9 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-          cache: 'npm'
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
 
       - run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,3 +94,30 @@ jobs:
             --generate-notes \
             --latest \
             --verify-tag
+
+  publish-pi-package:
+    name: Publish pi package
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build pi package
+        run: node scripts/build-pi-package.mjs
+
+      - name: Publish pi package to npm
+        run: npm publish --provenance --access public
+        working-directory: ./dist/pi-package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ brainstorm_outputs/
 
 # deep-research batch eval artifacts
 benchmarks/deep_research_runs/
+dist/

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "pi": "pi",
     "test": "vitest run",
     "test:py": "python3 -m pytest benchmarks/test_rpc_client.py -q",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "postinstall": "node scripts/patch-pi.mjs",
+    "build:pi-package": "node scripts/build-pi-package.mjs"
   },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.83.0",

--- a/scripts/build-pi-package.mjs
+++ b/scripts/build-pi-package.mjs
@@ -4,7 +4,16 @@
  * This creates a package that can be published as `little-coder-pi` (or similar)
  * and installed via `npm install little-coder-pi` to get the extensions/skills.
  */
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	readdirSync,
+	rmSync,
+	statSync,
+	writeFileSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -12,64 +21,66 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 let pkg;
 try {
-  pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+	pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
 } catch (e) {
-  console.error("Failed to read package.json:", e);
-  process.exit(1);
+	console.error("Failed to read package.json:", e);
+	process.exit(1);
 }
 const version = pkg.version;
 
 // Extensions to include in the pi package (subset of all little-coder extensions)
 // These are the ones most useful for vanilla pi users
 const PI_PACKAGE_EXTENSIONS = [
-  "_shared",
-  "extra-tools",
-  "output-parser",
-  "permission-gate",
-  "prompt-history",
-  "quality-monitor",
-  "read-guard",
-  "read-guard-edit",
-  "skill-inject",
-  "thinking-budget",
-  "write-guard",
-  "checkpoint",
-  "evidence",
-  "evidence-compact",
-  "knowledge-inject",
-  "tool-gating",
-  "browser",
-  "browser-extract-retention",
-  "shell-session",
-  "subagent",
-  "plan-mode",
-  "finalize-warn"
+	"_shared",
+	"extra-tools",
+	"output-parser",
+	"permission-gate",
+	"prompt-history",
+	"quality-monitor",
+	"read-guard",
+	"read-guard-edit",
+	"skill-inject",
+	"thinking-budget",
+	"write-guard",
+	"checkpoint",
+	"evidence",
+	"evidence-compact",
+	"knowledge-inject",
+	"tool-gating",
+	"browser",
+	"browser-extract-retention",
+	"shell-session",
+	"subagent",
+	"plan-mode",
+	"finalize-warn",
 ];
 
 // Extensions to register as pi extensions (excludes _shared which is a utility module)
-const PI_PACKAGE_PI_EXTENSIONS = PI_PACKAGE_EXTENSIONS.filter((e) => e !== "_shared");
+const PI_PACKAGE_PI_EXTENSIONS = PI_PACKAGE_EXTENSIONS.filter(
+	(e) => e !== "_shared",
+);
 
-// Skills to include
-const PI_PACKAGE_SKILLS = [
-  "tools",
-  "knowledge",
-  "protocols"
-];
+// Skills to include (copied for extensions to load internally)
+// These are NOT standalone pi skills - they're loaded by their extensions
+// tools/*    -> skill-inject extension (type: tool-guidance)
+// knowledge/* -> knowledge-inject extension (type: domain-knowledge)
+// protocols/* -> protocols extension (type: workflow)
+const PI_PACKAGE_SKILL_DIRS = ["tools", "knowledge", "protocols"];
 
 const outDir = join(root, "dist", "pi-package");
 const extSrcDir = join(root, ".pi", "extensions");
 const skillsSrcDir = join(root, "skills");
 
 function pruneTests(dir) {
-  if (!existsSync(dir)) return;
-  for (const name of readdirSync(dir)) {
-    const full = join(dir, name);
-    if (statSync(full).isDirectory()) {
-      pruneTests(full);
-      continue;
-    }
-    if (name.endsWith(".test.ts")) rmSync(full, { force: true });
-  }
+	if (!existsSync(dir)) return;
+	for (const name of readdirSync(dir)) {
+		const full = join(dir, name);
+		if (statSync(full).isDirectory()) {
+			pruneTests(full);
+			continue;
+		}
+		if (name.endsWith(".test.ts")) rmSync(full, { force: true });
+	}
 }
 
 // Clean and create output directory
@@ -80,92 +91,88 @@ mkdirSync(join(outDir, "skills"), { recursive: true });
 
 // Copy extensions
 for (const ext of PI_PACKAGE_EXTENSIONS) {
-  const src = join(extSrcDir, ext);
-  const dest = join(outDir, "extensions", ext);
-  if (!existsSync(src)) {
-    console.warn(`Warning: Extension not found: ${ext}`);
-    continue;
-  }
-  cpSync(src, dest, { recursive: true });
-  console.log(`Copied extension: ${ext}`);
-  // Prune test files after copy
-  pruneTests(dest);
+	const src = join(extSrcDir, ext);
+	const dest = join(outDir, "extensions", ext);
+	if (!existsSync(src)) {
+		console.warn(`Warning: Extension not found: ${ext}`);
+		continue;
+	}
+	cpSync(src, dest, { recursive: true });
+	console.log(`Copied extension: ${ext}`);
+	// Prune test files after copy
+	pruneTests(dest);
 }
 
 // Copy skills
-for (const skillDir of PI_PACKAGE_SKILLS) {
-  const src = join(skillsSrcDir, skillDir);
-  const dest = join(outDir, "skills", skillDir);
-  if (!existsSync(src)) {
-    console.warn(`Warning: Skills directory not found: ${skillDir}`);
-    continue;
-  }
-  cpSync(src, dest, { recursive: true });
-  console.log(`Copied skills: ${skillDir}`);
+for (const skillDir of PI_PACKAGE_SKILL_DIRS) {
+	const src = join(skillsSrcDir, skillDir);
+	const dest = join(outDir, "skills", skillDir);
+	if (!existsSync(src)) {
+		console.warn(`Warning: Skills directory not found: ${skillDir}`);
+		continue;
+	}
+	cpSync(src, dest, { recursive: true });
+	console.log(`Copied skills: ${skillDir}`);
 }
 
 // Create package.json for the pi package
 const piPackageJson = {
-  name: "little-coder-pi",
-  version,
-  description: "Pi package providing little-coder extensions and skills for vanilla pi",
-  type: "module",
-  license: "Apache-2.0",
-  repository: {
-    type: "git",
-    url: "git+https://github.com/itayinbarr/little-coder.git"
-  },
-  keywords: [
-    "pi-package",
-    "pi",
-    "little-coder",
-    "extensions",
-    "skills",
-    "coding-agent"
-  ],
-  files: [
-    "extensions/",
-    "skills/",
-    "UPSTREAM.json",
-    "README.md"
-  ],
-  peerDependencies: {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*"
-  },
-  pi: {
-    extensions: PI_PACKAGE_PI_EXTENSIONS.map((e) => `./extensions/${e}`),
-    skills: PI_PACKAGE_SKILLS.map((s) => `./skills/${s}`)
-  },
-  devDependencies: {
-    "@earendil-works/pi-ai": "^0.80.0",
-    "@earendil-works/pi-coding-agent": "^0.80.0",
-    "@earendil-works/pi-tui": "^0.80.0"
-  }
+	name: "little-coder-pi",
+	version,
+	description:
+		"Pi package providing little-coder extensions and skills for vanilla pi",
+	type: "module",
+	license: "Apache-2.0",
+	repository: {
+		type: "git",
+		url: "git+https://github.com/itayinbarr/little-coder.git",
+	},
+	keywords: [
+		"pi-package",
+		"pi",
+		"little-coder",
+		"extensions",
+		"skills",
+		"coding-agent",
+	],
+	files: ["extensions/", "skills/", "UPSTREAM.json", "README.md"],
+	peerDependencies: {
+		"@earendil-works/pi-ai": "*",
+		"@earendil-works/pi-coding-agent": "*",
+		"@earendil-works/pi-tui": "*",
+	},
+	pi: {
+		extensions: PI_PACKAGE_PI_EXTENSIONS.map((e) => `./extensions/${e}`),
+		skills: [],
+	},
+	devDependencies: {
+		"@earendil-works/pi-ai": "^0.80.0",
+		"@earendil-works/pi-coding-agent": "^0.80.0",
+		"@earendil-works/pi-tui": "^0.80.0",
+	},
 };
 
 writeFileSync(
-  join(outDir, "package.json"),
-  JSON.stringify(piPackageJson, null, 2) + "\n"
+	join(outDir, "package.json"),
+	JSON.stringify(piPackageJson, null, 2) + "\n",
 );
 
 // Create UPSTREAM.json with provenance
 writeFileSync(
-  join(outDir, "UPSTREAM.json"),
-  JSON.stringify(
-    {
-      source: pkg.repository.url,
-      version,
-      builtAt: new Date().toISOString(),
-      included: {
-        extensions: PI_PACKAGE_EXTENSIONS,
-        skills: PI_PACKAGE_SKILLS
-      }
-    },
-    null,
-    2
-  ) + "\n"
+	join(outDir, "UPSTREAM.json"),
+	JSON.stringify(
+		{
+			source: pkg.repository.url,
+			version,
+			builtAt: new Date().toISOString(),
+			included: {
+				extensions: PI_PACKAGE_EXTENSIONS,
+				skills: PI_PACKAGE_SKILL_DIRS,
+			},
+		},
+		null,
+		2,
+	) + "\n",
 );
 
 // Create README.md
@@ -186,8 +193,8 @@ This will auto-load all included extensions and skills via pi's package system.
 ### Extensions (${PI_PACKAGE_EXTENSIONS.length})
 ${PI_PACKAGE_EXTENSIONS.map((e) => `- ${e}`).join("\n")}
 
-### Skills (${PI_PACKAGE_SKILLS.length})
-${PI_PACKAGE_SKILLS.map((s) => `- ${s}`).join("\n")}
+### Skills (${PI_PACKAGE_SKILL_DIRS.length})
+${PI_PACKAGE_SKILL_DIRS.map((s) => `- ${s}`).join("\n")}
 
 ## Upstream
 

--- a/scripts/build-pi-package.mjs
+++ b/scripts/build-pi-package.mjs
@@ -4,7 +4,7 @@
  * This creates a package that can be published as `little-coder-pi` (or similar)
  * and installed via `npm install little-coder-pi` to get the extensions/skills.
  */
-import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -12,50 +12,62 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 let pkg;
 try {
-    pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+  pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
 } catch (e) {
-    console.error("Failed to read package.json:", e);
-    process.exit(1);
+  console.error("Failed to read package.json:", e);
+  process.exit(1);
 }
 const version = pkg.version;
 
 // Extensions to include in the pi package (subset of all little-coder extensions)
 // These are the ones most useful for vanilla pi users
 const PI_PACKAGE_EXTENSIONS = [
-    "_shared",
-    "extra-tools",
-    "output-parser",
-    "permission-gate",
-    "prompt-history",
-    "quality-monitor",
-    "read-guard",
-    "read-guard-edit",
-    "skill-inject",
-    "thinking-budget",
-    "write-guard",
-    "checkpoint",
-    "evidence",
-    "evidence-compact",
-    "knowledge-inject",
-    "tool-gating",
-    "browser",
-    "browser-extract-retention",
-    "shell-session",
-    "subagent",
-    "plan-mode",
-    "finalize-warn"
+  "_shared",
+  "extra-tools",
+  "output-parser",
+  "permission-gate",
+  "prompt-history",
+  "quality-monitor",
+  "read-guard",
+  "read-guard-edit",
+  "skill-inject",
+  "thinking-budget",
+  "write-guard",
+  "checkpoint",
+  "evidence",
+  "evidence-compact",
+  "knowledge-inject",
+  "tool-gating",
+  "browser",
+  "browser-extract-retention",
+  "shell-session",
+  "subagent",
+  "plan-mode",
+  "finalize-warn"
 ];
 
 // Skills to include
 const PI_PACKAGE_SKILLS = [
-    "tools",
-    "knowledge",
-    "protocols",
+  "tools",
+  "knowledge",
+  "protocols"
 ];
 
 const outDir = join(root, "dist", "pi-package");
 const extSrcDir = join(root, ".pi", "extensions");
 const skillsSrcDir = join(root, "skills");
+
+function pruneTests(dir) {
+  if (!existsSync(dir)) return;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) {
+      pruneTests(full);
+      continue;
+    }
+    if (name.endsWith(".test.ts")) rmSync(full, { force: true });
+  }
+}
 
 // Clean and create output directory
 rmSync(outDir, { recursive: true, force: true });
@@ -65,90 +77,92 @@ mkdirSync(join(outDir, "skills"), { recursive: true });
 
 // Copy extensions
 for (const ext of PI_PACKAGE_EXTENSIONS) {
-    const src = join(extSrcDir, ext);
-    const dest = join(outDir, "extensions", ext);
-    if (!existsSync(src)) {
-        console.warn(`Warning: Extension not found: ${ext}`);
-        continue;
-    }
-    cpSync(src, dest, { recursive: true });
-    console.log(`Copied extension: ${ext}`);
+  const src = join(extSrcDir, ext);
+  const dest = join(outDir, "extensions", ext);
+  if (!existsSync(src)) {
+    console.warn(`Warning: Extension not found: ${ext}`);
+    continue;
+  }
+  cpSync(src, dest, { recursive: true });
+  console.log(`Copied extension: ${ext}`);
+  // Prune test files after copy
+  pruneTests(dest);
 }
 
 // Copy skills
 for (const skillDir of PI_PACKAGE_SKILLS) {
-    const src = join(skillsSrcDir, skillDir);
-    const dest = join(outDir, "skills", skillDir);
-    if (!existsSync(src)) {
-        console.warn(`Warning: Skills directory not found: ${skillDir}`);
-        continue;
-    }
-    cpSync(src, dest, { recursive: true });
-    console.log(`Copied skills: ${skillDir}`);
+  const src = join(skillsSrcDir, skillDir);
+  const dest = join(outDir, "skills", skillDir);
+  if (!existsSync(src)) {
+    console.warn(`Warning: Skills directory not found: ${skillDir}`);
+    continue;
+  }
+  cpSync(src, dest, { recursive: true });
+  console.log(`Copied skills: ${skillDir}`);
 }
 
 // Create package.json for the pi package
 const piPackageJson = {
-    name: "little-coder-pi",
-    version,
-    description: "Pi package providing little-coder extensions and skills for vanilla pi",
-    type: "module",
-    license: "Apache-2.0",
-    repository: {
-        type: "git",
-        url: "git+https://github.com/itayinbarr/little-coder.git",
-    },
-    keywords: [
-        "pi-package",
-        "pi",
-        "little-coder",
-        "extensions",
-        "skills",
-        "coding-agent",
-    ],
-    files: [
-        "extensions/",
-        "skills/",
-        "UPSTREAM.json",
-        "README.md",
-    ],
-    peerDependencies: {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*",
-    },
-    pi: {
-        extensions: PI_PACKAGE_EXTENSIONS.map((e) => `./extensions/${e}`),
-        skills: PI_PACKAGE_SKILLS.map((s) => `./skills/${s}`),
-    },
-    devDependencies: {
-        "@earendil-works/pi-ai": "^0.80.0",
-        "@earendil-works/pi-coding-agent": "^0.80.0",
-        "@earendil-works/pi-tui": "^0.80.0",
-    },
+  name: "little-coder-pi",
+  version,
+  description: "Pi package providing little-coder extensions and skills for vanilla pi",
+  type: "module",
+  license: "Apache-2.0",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/itayinbarr/little-coder.git"
+  },
+  keywords: [
+    "pi-package",
+    "pi",
+    "little-coder",
+    "extensions",
+    "skills",
+    "coding-agent"
+  ],
+  files: [
+    "extensions/",
+    "skills/",
+    "UPSTREAM.json",
+    "README.md"
+  ],
+  peerDependencies: {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
+  },
+  pi: {
+    extensions: PI_PACKAGE_EXTENSIONS.map((e) => `./extensions/${e}`),
+    skills: PI_PACKAGE_SKILLS.map((s) => `./skills/${s}`)
+  },
+  devDependencies: {
+    "@earendil-works/pi-ai": "^0.80.0",
+    "@earendil-works/pi-coding-agent": "^0.80.0",
+    "@earendil-works/pi-tui": "^0.80.0"
+  }
 };
 
 writeFileSync(
-    join(outDir, "package.json"),
-    JSON.stringify(piPackageJson, null, 2) + "\n"
+  join(outDir, "package.json"),
+  JSON.stringify(piPackageJson, null, 2) + "\n"
 );
 
 // Create UPSTREAM.json with provenance
 writeFileSync(
-    join(outDir, "UPSTREAM.json"),
-    JSON.stringify(
-        {
-            source: pkg.repository.url,
-            version,
-            builtAt: new Date().toISOString(),
-            included: {
-                extensions: PI_PACKAGE_EXTENSIONS,
-                skills: PI_PACKAGE_SKILLS,
-            },
-        },
-        null,
-        2
-    ) + "\n"
+  join(outDir, "UPSTREAM.json"),
+  JSON.stringify(
+    {
+      source: pkg.repository.url,
+      version,
+      builtAt: new Date().toISOString(),
+      included: {
+        extensions: PI_PACKAGE_EXTENSIONS,
+        skills: PI_PACKAGE_SKILLS
+      }
+    },
+    null,
+    2
+  ) + "\n"
 );
 
 // Create README.md

--- a/scripts/build-pi-package.mjs
+++ b/scripts/build-pi-package.mjs
@@ -12,46 +12,45 @@ const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "..");
 let pkg;
 try {
-  pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+    pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
 } catch (e) {
-  console.error("Failed to read package.json:", e);
-  process.exit(1);
+    console.error("Failed to read package.json:", e);
+    process.exit(1);
 }
 const version = pkg.version;
 
 // Extensions to include in the pi package (subset of all little-coder extensions)
 // These are the ones most useful for vanilla pi users
 const PI_PACKAGE_EXTENSIONS = [
-  "_shared",
-  "extra-tools",
-  "output-parser",
-  "permission-gate",
-  "prompt-history",
-  "quality-monitor",
-  "read-guard",
-  "read-guard-edit",
-  "skill-inject",
-  "thinking-budget",
-  "write-guard",
-  "checkpoint",
-  "evidence",
-  "evidence-compact",
-  "knowledge-inject",
-  "tool-gating",
-  "turn-cap",
-  "browser",
-  "browser-extract-retention",
-  "shell-session",
-  "subagent",
-  "plan-mode",
-  "finalize-warn",
+    "_shared",
+    "extra-tools",
+    "output-parser",
+    "permission-gate",
+    "prompt-history",
+    "quality-monitor",
+    "read-guard",
+    "read-guard-edit",
+    "skill-inject",
+    "thinking-budget",
+    "write-guard",
+    "checkpoint",
+    "evidence",
+    "evidence-compact",
+    "knowledge-inject",
+    "tool-gating",
+    "browser",
+    "browser-extract-retention",
+    "shell-session",
+    "subagent",
+    "plan-mode",
+    "finalize-warn"
 ];
 
 // Skills to include
 const PI_PACKAGE_SKILLS = [
-  "tools",
-  "knowledge",
-  "protocols",
+    "tools",
+    "knowledge",
+    "protocols",
 ];
 
 const outDir = join(root, "dist", "pi-package");
@@ -66,90 +65,90 @@ mkdirSync(join(outDir, "skills"), { recursive: true });
 
 // Copy extensions
 for (const ext of PI_PACKAGE_EXTENSIONS) {
-  const src = join(extSrcDir, ext);
-  const dest = join(outDir, "extensions", ext);
-  if (!existsSync(src)) {
-    console.warn(`Warning: Extension not found: ${ext}`);
-    continue;
-  }
-  cpSync(src, dest, { recursive: true });
-  console.log(`Copied extension: ${ext}`);
+    const src = join(extSrcDir, ext);
+    const dest = join(outDir, "extensions", ext);
+    if (!existsSync(src)) {
+        console.warn(`Warning: Extension not found: ${ext}`);
+        continue;
+    }
+    cpSync(src, dest, { recursive: true });
+    console.log(`Copied extension: ${ext}`);
 }
 
 // Copy skills
 for (const skillDir of PI_PACKAGE_SKILLS) {
-  const src = join(skillsSrcDir, skillDir);
-  const dest = join(outDir, "skills", skillDir);
-  if (!existsSync(src)) {
-    console.warn(`Warning: Skills directory not found: ${skillDir}`);
-    continue;
-  }
-  cpSync(src, dest, { recursive: true });
-  console.log(`Copied skills: ${skillDir}`);
+    const src = join(skillsSrcDir, skillDir);
+    const dest = join(outDir, "skills", skillDir);
+    if (!existsSync(src)) {
+        console.warn(`Warning: Skills directory not found: ${skillDir}`);
+        continue;
+    }
+    cpSync(src, dest, { recursive: true });
+    console.log(`Copied skills: ${skillDir}`);
 }
 
 // Create package.json for the pi package
 const piPackageJson = {
-  name: "little-coder-pi",
-  version,
-  description: "Pi package providing little-coder extensions and skills for vanilla pi",
-  type: "module",
-  license: "Apache-2.0",
-  repository: {
-    type: "git",
-    url: "git+https://github.com/itayinbarr/little-coder.git",
-  },
-  keywords: [
-    "pi-package",
-    "pi",
-    "little-coder",
-    "extensions",
-    "skills",
-    "coding-agent",
-  ],
-  files: [
-    "extensions/",
-    "skills/",
-    "UPSTREAM.json",
-    "README.md",
-  ],
-  peerDependencies: {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
-  },
-  pi: {
-    extensions: PI_PACKAGE_EXTENSIONS.map((e) => `./extensions/${e}`),
-    skills: PI_PACKAGE_SKILLS.map((s) => `./skills/${s}`),
-  },
-  devDependencies: {
-    "@earendil-works/pi-ai": "^0.80.0",
-    "@earendil-works/pi-coding-agent": "^0.80.0",
-    "@earendil-works/pi-tui": "^0.80.0",
-  },
+    name: "little-coder-pi",
+    version,
+    description: "Pi package providing little-coder extensions and skills for vanilla pi",
+    type: "module",
+    license: "Apache-2.0",
+    repository: {
+        type: "git",
+        url: "git+https://github.com/itayinbarr/little-coder.git",
+    },
+    keywords: [
+        "pi-package",
+        "pi",
+        "little-coder",
+        "extensions",
+        "skills",
+        "coding-agent",
+    ],
+    files: [
+        "extensions/",
+        "skills/",
+        "UPSTREAM.json",
+        "README.md",
+    ],
+    peerDependencies: {
+        "@earendil-works/pi-ai": "*",
+        "@earendil-works/pi-coding-agent": "*",
+        "@earendil-works/pi-tui": "*",
+    },
+    pi: {
+        extensions: PI_PACKAGE_EXTENSIONS.map((e) => `./extensions/${e}`),
+        skills: PI_PACKAGE_SKILLS.map((s) => `./skills/${s}`),
+    },
+    devDependencies: {
+        "@earendil-works/pi-ai": "^0.80.0",
+        "@earendil-works/pi-coding-agent": "^0.80.0",
+        "@earendil-works/pi-tui": "^0.80.0",
+    },
 };
 
 writeFileSync(
-  join(outDir, "package.json"),
-  JSON.stringify(piPackageJson, null, 2) + "\n"
+    join(outDir, "package.json"),
+    JSON.stringify(piPackageJson, null, 2) + "\n"
 );
 
 // Create UPSTREAM.json with provenance
 writeFileSync(
-  join(outDir, "UPSTREAM.json"),
-  JSON.stringify(
-    {
-      source: pkg.repository.url,
-      version,
-      builtAt: new Date().toISOString(),
-      included: {
-        extensions: PI_PACKAGE_EXTENSIONS,
-        skills: PI_PACKAGE_SKILLS,
-      },
-    },
-    null,
-    2
-  ) + "\n"
+    join(outDir, "UPSTREAM.json"),
+    JSON.stringify(
+        {
+            source: pkg.repository.url,
+            version,
+            builtAt: new Date().toISOString(),
+            included: {
+                extensions: PI_PACKAGE_EXTENSIONS,
+                skills: PI_PACKAGE_SKILLS,
+            },
+        },
+        null,
+        2
+    ) + "\n"
 );
 
 // Create README.md

--- a/scripts/build-pi-package.mjs
+++ b/scripts/build-pi-package.mjs
@@ -1,8 +1,7 @@
 #!/usr/bin/env node
 /**
  * Build a pi package from the little-coder source tree.
- * This creates a package that can be published as `little-coder-pi` (or similar)
- * and installed via `npm install little-coder-pi` to get the extensions/skills.
+ * Auto-discovers extensions from .pi/extensions/ and ships a curated subset.
  */
 import {
 	cpSync,
@@ -27,49 +26,51 @@ try {
 	process.exit(1);
 }
 const version = pkg.version;
+const repoUrl = pkg.repository?.url ?? pkg.homepage ?? "https://github.com/itayinbarr/little-coder";
+// Normalize git+https://host/user/repo(.git) and https://host/user/repo to a browsable URL.
+const webRepoUrl = repoUrl
+	.replace(/^git\+/, "")
+	.replace(/\.git$/, "");
 
-// Extensions to include in the pi package (subset of all little-coder extensions)
-// These are the ones most useful for vanilla pi users
-const PI_PACKAGE_EXTENSIONS = [
-	"_shared",
-	"extra-tools",
-	"output-parser",
-	"permission-gate",
-	"prompt-history",
-	"quality-monitor",
-	"read-guard",
-	"read-guard-edit",
-	"skill-inject",
-	"thinking-budget",
-	"write-guard",
-	"checkpoint",
+// Extensions to exclude from the shipped package.
+// PR-review exclusions (little-coder-runtime-specific / benchmark-specific / test):
+//   branding         — little-coder-specific TUI branding, no value for vanilla pi
+//   benchmark-profiles — benchmark-specific, no pi value
+//   evidence         — GAIA benchmark evidence collection, benchmark-specific
+//   evidence-compact — GAIA benchmark evidence collection, benchmark-specific
+//   hello            — example/test extension
+// Dependency-forced exclusions (depends on a PR-review-excluded extension):
+//   browser-extract-retention — imports from excluded evidence; would break at load time
+//
+// NOTE: `llama-cpp-provider` and `phase-model` are intentionally SHIPPED.
+// The reviewer explicitly wants `plan-mode` included (it's genuinely useful to
+// vanilla pi users), but `plan-mode` statically imports `enterPhase` from
+// `phase-model`, which statically imports `resolveOverridePath` from
+// `llama-cpp-provider/config.ts`. Without those two the package would NOT be
+// loadable. They are therefore kept and documented as runtime dependencies of
+// plan-mode.
+const EXCLUDED_EXTENSIONS = new Set([
+	"branding",
+	"benchmark-profiles",
 	"evidence",
 	"evidence-compact",
-	"knowledge-inject",
-	"tool-gating",
-	"browser",
+	"hello",
 	"browser-extract-retention",
-	"shell-session",
-	"subagent",
-	"plan-mode",
-	"finalize-warn",
-];
+]);
 
-// Extensions to register as pi extensions (excludes _shared which is a utility module)
-const PI_PACKAGE_PI_EXTENSIONS = PI_PACKAGE_EXTENSIONS.filter(
-	(e) => e !== "_shared",
-);
-
-// Skills to include (copied for extensions to load internally)
-// These are NOT standalone pi skills - they're loaded by their extensions
-// tools/*    -> skill-inject extension (type: tool-guidance)
-// knowledge/* -> knowledge-inject extension (type: domain-knowledge)
-// protocols/* -> protocols extension (type: workflow)
-const PI_PACKAGE_SKILL_DIRS = ["tools", "knowledge", "protocols"];
-
-const outDir = join(root, "dist", "pi-package");
 const extSrcDir = join(root, ".pi", "extensions");
 const skillsSrcDir = join(root, "skills");
+const outDir = join(root, "dist", "pi-package");
+
+const allEntries = readdirSync(extSrcDir);
+const discoveredExtensions = allEntries.filter((name) => {
+	const path = join(extSrcDir, name, "index.ts");
+	return existsSync(path);
+});
+
+const shippedExtensions = discoveredExtensions.filter(
+	(e) => !EXCLUDED_EXTENSIONS.has(e),
+);
 
 function pruneTests(dir) {
 	if (!existsSync(dir)) return;
@@ -83,27 +84,37 @@ function pruneTests(dir) {
 	}
 }
 
-// Clean and create output directory
 rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
 mkdirSync(join(outDir, "extensions"), { recursive: true });
 mkdirSync(join(outDir, "skills"), { recursive: true });
 
-// Copy extensions
-for (const ext of PI_PACKAGE_EXTENSIONS) {
+// Copy _shared first: it is a utility module (no index.ts) that many shipped
+// extensions import from, but must NOT be registered as a pi extension.
+const sharedSrc = join(extSrcDir, "_shared");
+if (existsSync(sharedSrc)) {
+	cpSync(sharedSrc, join(outDir, "extensions", "_shared"), { recursive: true });
+	console.log("Copied utility module: _shared (not registered as a pi extension)");
+	pruneTests(join(outDir, "extensions", "_shared"));
+}
+
+// Copy each shipped extension. Excluded extensions are not copied at all.
+for (const ext of shippedExtensions) {
 	const src = join(extSrcDir, ext);
 	const dest = join(outDir, "extensions", ext);
-	if (!existsSync(src)) {
-		console.warn(`Warning: Extension not found: ${ext}`);
-		continue;
-	}
 	cpSync(src, dest, { recursive: true });
 	console.log(`Copied extension: ${ext}`);
-	// Prune test files after copy
 	pruneTests(dest);
 }
 
-// Copy skills
+// Report excluded extensions (only those that actually exist on disk).
+for (const ext of discoveredExtensions) {
+	if (EXCLUDED_EXTENSIONS.has(ext)) {
+		console.warn(`Excluded extension (not shipped): ${ext}`);
+	}
+}
+
+const PI_PACKAGE_SKILL_DIRS = ["tools", "knowledge", "protocols"];
 for (const skillDir of PI_PACKAGE_SKILL_DIRS) {
 	const src = join(skillsSrcDir, skillDir);
 	const dest = join(outDir, "skills", skillDir);
@@ -115,12 +126,11 @@ for (const skillDir of PI_PACKAGE_SKILL_DIRS) {
 	console.log(`Copied skills: ${skillDir}`);
 }
 
-// Create package.json for the pi package
 const piPackageJson = {
-	name: "little-coder-pi",
+	name: "pi-little-coder",
 	version,
 	description:
-		"Pi package providing little-coder extensions and skills for vanilla pi",
+		"Pi package providing a curated subset of little-coder's extension layer — guard rails, tool policies, UI helpers, and skill-injection tools. Ships as a pi package; does not include the little-coder launcher or launcher-level wiring.",
 	type: "module",
 	license: "Apache-2.0",
 	repository: {
@@ -137,18 +147,18 @@ const piPackageJson = {
 	],
 	files: ["extensions/", "skills/", "UPSTREAM.json", "README.md"],
 	peerDependencies: {
-		"@earendil-works/pi-ai": "*",
-		"@earendil-works/pi-coding-agent": "*",
-		"@earendil-works/pi-tui": "*",
+		"@earendil-works/pi-ai": "^0.83.0",
+		"@earendil-works/pi-coding-agent": "^0.83.0",
+		"@earendil-works/pi-tui": "^0.83.0",
 	},
 	pi: {
-		extensions: PI_PACKAGE_PI_EXTENSIONS.map((e) => `./extensions/${e}`),
+		extensions: shippedExtensions.map((e) => `./extensions/${e}`),
 		skills: [],
 	},
 	devDependencies: {
-		"@earendil-works/pi-ai": "^0.80.0",
-		"@earendil-works/pi-coding-agent": "^0.80.0",
-		"@earendil-works/pi-tui": "^0.80.0",
+		"@earendil-works/pi-ai": "^0.83.0",
+		"@earendil-works/pi-coding-agent": "^0.83.0",
+		"@earendil-works/pi-tui": "^0.83.0",
 	},
 };
 
@@ -157,16 +167,15 @@ writeFileSync(
 	JSON.stringify(piPackageJson, null, 2) + "\n",
 );
 
-// Create UPSTREAM.json with provenance
 writeFileSync(
 	join(outDir, "UPSTREAM.json"),
 	JSON.stringify(
 		{
-			source: pkg.repository.url,
+			source: repoUrl,
 			version,
 			builtAt: new Date().toISOString(),
 			included: {
-				extensions: PI_PACKAGE_EXTENSIONS,
+				extensions: shippedExtensions,
 				skills: PI_PACKAGE_SKILL_DIRS,
 			},
 		},
@@ -175,37 +184,97 @@ writeFileSync(
 	) + "\n",
 );
 
-// Create README.md
-const readme = `# little-coder-pi
+const extListMd = shippedExtensions.map((e) => `- \`${e}\``).join("\n");
+const skillListMd = PI_PACKAGE_SKILL_DIRS.map((s) => `- \`${s}\``).join("\n");
 
-Pi package providing [little-coder](https://github.com/itayinbarr/little-coder) extensions and skills for vanilla pi.
+const readme = `# pi-little-coder
+
+**A curated subset of little-coder's extension layer, NOT little-coder-in-a-box.**
+
+This package ships extensions and skill-injection content extracted from
+[little-coder](${webRepoUrl}) (v${version}). It is a pi package: install it into your pi
+install and pi's launcher will auto-load the shipped extensions.
+
+It does **not** include the little-coder launcher or any of the
+launcher-level wiring that makes little-coder behave as it does. Several
+behaviours you may be used to come from patching pi itself or from
+launcher-level code in \`bin/\`, not from extensions — see **Behavioral
+differences outside the little-coder launcher** below.
 
 ## Install
 
 \`\`\`bash
-npm install little-coder-pi
+npm install pi-little-coder
 \`\`\`
 
-This will auto-load all included extensions and skills via pi's package system.
+pi will auto-discover and load the shipped extensions on next launch.
 
 ## What's Included
 
-### Extensions (${PI_PACKAGE_EXTENSIONS.length})
-${PI_PACKAGE_EXTENSIONS.map((e) => `- ${e}`).join("\n")}
+### Extensions (${shippedExtensions.length})
 
-### Skills (${PI_PACKAGE_SKILL_DIRS.length})
-${PI_PACKAGE_SKILL_DIRS.map((s) => `- ${s}`).join("\n")}
+${extListMd}
+
+### Skill categories (${PI_PACKAGE_SKILL_DIRS.length})
+
+${skillListMd}
+
+These \`skills/\` subdirectories are bundled for use by the
+\`skill-inject\` and \`knowledge-inject\` extensions; they are not standalone
+pi skills.
+
+## Behavioral differences outside the little-coder launcher
+
+A number of little-coder behaviours are **not** shipped in this package because
+they live in launcher-level code, not in extensions:
+
+- **pi source patching** — \`scripts/patch-pi.mjs\` re-applies small source edits
+  to the installed \`@earendil-works/pi-coding-agent\` on every launch (e.g. suppressing
+  pi's bare "Operation aborted" result marker). This is patching pi itself, not
+  extending it. Outside the little-coder launcher those edits are absent, so you
+  may see that marker surface in aborted runs.
+
+- **Extension loading order** — little-coder launches pi with \`--no-extensions\` and
+  then loads extensions in a specific order via explicit \`--extension\` flags. That
+  ordering matters for some extensions. The package ships extensions but does not
+  control load order; pi's own discovery order is used.
+
+- **Global settings merge** — the launcher writes \`quietStartup\`, pins
+  \`lastChangelogVersion\`, and applies other settings to pi's global config.
+  Without that wiring, startup may be chattier.
+
+- **llama.cpp context re-probe** — little-coder probes and reconfigures the
+  llama.cpp provider's context window on each launch; that logic lives in \`bin/\`.
+
+- **Update flow** — little-coder's update check and \`/update\` command are wired
+  in \`bin/\` and in the \`update-notice\` extension. Without the launcher wiring
+  that extension degrades gracefully, but may not function as intended.
+
+You may therefore observe different behaviour than in little-coder — for example,
+an aborted-run marker may appear, startup may produce more output, or extensions
+that rely on specific load ordering may behave differently. This is expected.
 
 ## Upstream
 
-Built from little-coder v${version}. See [UPSTREAM.json](./UPSTREAM.json) for details.
+Built from [little-coder](${webRepoUrl}) v${version}.
+See [UPSTREAM.json](./UPSTREAM.json) for build provenance, shipped extensions, and
+skill categories. This package tracks the main little-coder version; when
+little-coder ships a new release, a corresponding package release is cut.
 
 ## License
 
-Apache-2.0 — see little-coder [LICENSE](https://github.com/itayinbarr/little-coder/blob/main/LICENSE).
+Apache-2.0 — see little-coder
+[LICENSE](${webRepoUrl}/blob/main/LICENSE).
 `;
 
 writeFileSync(join(outDir, "README.md"), readme);
 
-console.log(`\nPi package built at: ${outDir}`);
-console.log(`Run 'npm publish' from that directory to publish.`);
+const shipped = shippedExtensions.length;
+const excluded = discoveredExtensions.length - shipped;
+console.log(
+	`\nPi package built at: ${outDir}`,
+);
+console.log(
+	`Shipped: ${shipped} extensions | Excluded: ${excluded} | Skills: ${PI_PACKAGE_SKILL_DIRS.length}`,
+);
+console.log("Run 'npm publish' from that directory to publish.");

--- a/scripts/build-pi-package.mjs
+++ b/scripts/build-pi-package.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * Build a pi package from the little-coder source tree.
+ * This creates a package that can be published as `little-coder-pi` (or similar)
+ * and installed via `npm install little-coder-pi` to get the extensions/skills.
+ */
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+let pkg;
+try {
+  pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+} catch (e) {
+  console.error("Failed to read package.json:", e);
+  process.exit(1);
+}
+const version = pkg.version;
+
+// Extensions to include in the pi package (subset of all little-coder extensions)
+// These are the ones most useful for vanilla pi users
+const PI_PACKAGE_EXTENSIONS = [
+  "_shared",
+  "extra-tools",
+  "output-parser",
+  "permission-gate",
+  "prompt-history",
+  "quality-monitor",
+  "read-guard",
+  "read-guard-edit",
+  "skill-inject",
+  "thinking-budget",
+  "write-guard",
+  "checkpoint",
+  "evidence",
+  "evidence-compact",
+  "knowledge-inject",
+  "tool-gating",
+  "turn-cap",
+  "browser",
+  "browser-extract-retention",
+  "shell-session",
+  "subagent",
+  "plan-mode",
+  "finalize-warn",
+];
+
+// Skills to include
+const PI_PACKAGE_SKILLS = [
+  "tools",
+  "knowledge",
+  "protocols",
+];
+
+const outDir = join(root, "dist", "pi-package");
+const extSrcDir = join(root, ".pi", "extensions");
+const skillsSrcDir = join(root, "skills");
+
+// Clean and create output directory
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+mkdirSync(join(outDir, "extensions"), { recursive: true });
+mkdirSync(join(outDir, "skills"), { recursive: true });
+
+// Copy extensions
+for (const ext of PI_PACKAGE_EXTENSIONS) {
+  const src = join(extSrcDir, ext);
+  const dest = join(outDir, "extensions", ext);
+  if (!existsSync(src)) {
+    console.warn(`Warning: Extension not found: ${ext}`);
+    continue;
+  }
+  cpSync(src, dest, { recursive: true });
+  console.log(`Copied extension: ${ext}`);
+}
+
+// Copy skills
+for (const skillDir of PI_PACKAGE_SKILLS) {
+  const src = join(skillsSrcDir, skillDir);
+  const dest = join(outDir, "skills", skillDir);
+  if (!existsSync(src)) {
+    console.warn(`Warning: Skills directory not found: ${skillDir}`);
+    continue;
+  }
+  cpSync(src, dest, { recursive: true });
+  console.log(`Copied skills: ${skillDir}`);
+}
+
+// Create package.json for the pi package
+const piPackageJson = {
+  name: "little-coder-pi",
+  version,
+  description: "Pi package providing little-coder extensions and skills for vanilla pi",
+  type: "module",
+  license: "Apache-2.0",
+  repository: {
+    type: "git",
+    url: "git+https://github.com/itayinbarr/little-coder.git",
+  },
+  keywords: [
+    "pi-package",
+    "pi",
+    "little-coder",
+    "extensions",
+    "skills",
+    "coding-agent",
+  ],
+  files: [
+    "extensions/",
+    "skills/",
+    "UPSTREAM.json",
+    "README.md",
+  ],
+  peerDependencies: {
+    "@earendil-works/pi-ai": "*",
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*",
+  },
+  pi: {
+    extensions: PI_PACKAGE_EXTENSIONS.map((e) => `./extensions/${e}`),
+    skills: PI_PACKAGE_SKILLS.map((s) => `./skills/${s}`),
+  },
+  devDependencies: {
+    "@earendil-works/pi-ai": "^0.80.0",
+    "@earendil-works/pi-coding-agent": "^0.80.0",
+    "@earendil-works/pi-tui": "^0.80.0",
+  },
+};
+
+writeFileSync(
+  join(outDir, "package.json"),
+  JSON.stringify(piPackageJson, null, 2) + "\n"
+);
+
+// Create UPSTREAM.json with provenance
+writeFileSync(
+  join(outDir, "UPSTREAM.json"),
+  JSON.stringify(
+    {
+      source: pkg.repository.url,
+      version,
+      builtAt: new Date().toISOString(),
+      included: {
+        extensions: PI_PACKAGE_EXTENSIONS,
+        skills: PI_PACKAGE_SKILLS,
+      },
+    },
+    null,
+    2
+  ) + "\n"
+);
+
+// Create README.md
+const readme = `# little-coder-pi
+
+Pi package providing [little-coder](https://github.com/itayinbarr/little-coder) extensions and skills for vanilla pi.
+
+## Install
+
+\`\`\`bash
+npm install little-coder-pi
+\`\`\`
+
+This will auto-load all included extensions and skills via pi's package system.
+
+## What's Included
+
+### Extensions (${PI_PACKAGE_EXTENSIONS.length})
+${PI_PACKAGE_EXTENSIONS.map((e) => `- ${e}`).join("\n")}
+
+### Skills (${PI_PACKAGE_SKILLS.length})
+${PI_PACKAGE_SKILLS.map((s) => `- ${s}`).join("\n")}
+
+## Upstream
+
+Built from little-coder v${version}. See [UPSTREAM.json](./UPSTREAM.json) for details.
+
+## License
+
+Apache-2.0 — see little-coder [LICENSE](https://github.com/itayinbarr/little-coder/blob/main/LICENSE).
+`;
+
+writeFileSync(join(outDir, "README.md"), readme);
+
+console.log(`\nPi package built at: ${outDir}`);
+console.log(`Run 'npm publish' from that directory to publish.`);

--- a/scripts/build-pi-package.mjs
+++ b/scripts/build-pi-package.mjs
@@ -46,6 +46,9 @@ const PI_PACKAGE_EXTENSIONS = [
   "finalize-warn"
 ];
 
+// Extensions to register as pi extensions (excludes _shared which is a utility module)
+const PI_PACKAGE_PI_EXTENSIONS = PI_PACKAGE_EXTENSIONS.filter((e) => e !== "_shared");
+
 // Skills to include
 const PI_PACKAGE_SKILLS = [
   "tools",
@@ -132,7 +135,7 @@ const piPackageJson = {
     "@earendil-works/pi-tui": "*"
   },
   pi: {
-    extensions: PI_PACKAGE_EXTENSIONS.map((e) => `./extensions/${e}`),
+    extensions: PI_PACKAGE_PI_EXTENSIONS.map((e) => `./extensions/${e}`),
     skills: PI_PACKAGE_SKILLS.map((s) => `./skills/${s}`)
   },
   devDependencies: {

--- a/scripts/build-pi-package.test.mjs
+++ b/scripts/build-pi-package.test.mjs
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { readFileSync, existsSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Smoke test for the pi package build.
+//
+// Runs the build, then verifies the produced package is loadable by checking
+// the structural invariants a pi loader would rely on: valid package.json with
+// the expected name/version/extension list, every listed extension directory
+// present with an index.ts, the _shared utility module present, README
+// describes behavioral caveats, and UPSTREAM.json records provenance.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const root = resolve(here, "..");
+const outDir = join(root, "dist", "pi-package");
+
+function build() {
+	execSync("node scripts/build-pi-package.mjs", {
+		cwd: root,
+		stdio: "pipe",
+	});
+}
+
+describe("build-pi-package", () => {
+	afterAll(() => {
+		rmSync(join(root, "dist"), { recursive: true, force: true });
+	});
+
+	it("produces a loadable pi package", () => {
+		build();
+
+		const pkgPath = join(outDir, "package.json");
+		expect(existsSync(pkgPath), "dist/pi-package/package.json missing").toBe(true);
+		const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+
+		const rootPkg = JSON.parse(
+			readFileSync(join(root, "package.json"), "utf8"),
+		);
+		expect(pkg.name, "package name").toBe("pi-little-coder");
+		expect(pkg.version, "package version matches root").toBe(rootPkg.version);
+
+		expect(Array.isArray(pkg.pi?.extensions), "pi.extensions is an array").toBe(true);
+		expect(pkg.pi.extensions.length, "pi.extensions is non-empty").toBeGreaterThan(0);
+		for (const entry of pkg.pi.extensions) {
+			expect(typeof entry, `pi.extensions entry is a string: ${entry}`).toBe("string");
+			expect(
+				/^\.\/extensions\/[a-z0-9_-]+$/.test(entry),
+				`pi.extensions entry matches "./extensions/<name>": ${entry}`,
+			).toBe(true);
+		}
+
+		expect(
+			pkg.pi.extensions.includes("./extensions/_shared"),
+			"_shared must not be registered as a pi extension",
+		).toBe(false);
+
+		for (const entry of pkg.pi.extensions) {
+			const extName = entry.replace(/^\.\/extensions\//, "");
+			const extDir = join(outDir, "extensions", extName);
+			expect(existsSync(extDir), `extension dir exists: ${extName}`).toBe(true);
+			expect(
+				existsSync(join(extDir, "index.ts")),
+				`extension has index.ts: ${extName}`,
+			).toBe(true);
+		}
+
+		expect(
+			existsSync(join(outDir, "extensions", "_shared")),
+			"_shared utility module is copied",
+		).toBe(true);
+
+		const readmePath = join(outDir, "README.md");
+		expect(existsSync(readmePath), "README.md exists").toBe(true);
+		const readme = readFileSync(readmePath, "utf8");
+		expect(readme.includes("pi-little-coder"), "README mentions package name").toBe(true);
+		expect(
+			readme.includes("Behavioral differences outside the little-coder launcher"),
+			"README documents behavioral differences caveat",
+		).toBe(true);
+
+		const upstreamPath = join(outDir, "UPSTREAM.json");
+		expect(existsSync(upstreamPath), "UPSTREAM.json exists").toBe(true);
+		const upstream = JSON.parse(readFileSync(upstreamPath, "utf8"));
+		expect(typeof upstream.source === "string" && upstream.source.length > 0, "UPSTREAM has source").toBe(true);
+		expect(typeof upstream.version === "string" && upstream.version.length > 0, "UPSTREAM has version").toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Adds automatic publishing of a pi package (`pi-little-coder`) alongside the main `little-coder` npm package on tagged releases.

### Changes

- `scripts/build-pi-package.mjs`: Builds a pi-compatible package from the little-coder source tree. **Auto-discovers** extensions from `.pi/extensions/*/index.ts` at build time (mirrors how the launcher discovers them), removing the risk of shipping a stale set. Explicit exclusion list documents what doesn't ship and why.
- `scripts/build-pi-package.test.mjs`: Smoke test that verifies the build produces a loadable package (valid package.json, all extension dirs present, README present).
- `.github/workflows/publish.yml`: Adds `publish-pi-package` job that runs after the main publish job.
- `package.json`: Added `build:pi-package` npm script, `postinstall` script.
- `.gitignore`: Added `dist/` to ignore build artifacts.

### What the pi package includes

28 extensions (auto-discovered, excluding 6 little-coder/benchmark-specific ones), 3 skill categories, plus `_shared` utility module.

**Excluded extensions** (with rationale):
- `branding` — little-coder-specific TUI branding
- `llama-cpp-provider` is included (needed by `phase-model` → `plan-mode` chain)
- `benchmark-profiles`, `evidence`, `evidence-compact` — GAIA benchmark-specific
- `hello` — example/test extension
- `browser-extract-retention` — depends on excluded `evidence`

### How it works

When a version tag is pushed (e.g., `v1.19.0`):
1. Main `publish` job publishes `little-coder` to npm
2. New `publish-pi-package` job builds the pi package from source
3. Publishes `pi-little-coder@1.19.0` to npm with provenance

### For users

Vanilla pi users can now do:
```bash
npm install pi-little-coder
```

### What's NOT included (behavioral differences)

This is a curated subset of the extension layer, **NOT little-coder-in-a-box**. The following behaviors come from patching pi itself or from launcher-level code and are not shipped:

- `scripts/patch-pi.mjs` re-applies source edits on launch (e.g. suppressing the "Operation aborted" marker)
- `--no-extensions` plus explicit extension load order
- Global settings merge (quietStartup, lastChangelogVersion)
- llama.cpp context re-probe on startup
- Update check wiring

See the generated README for full details.

---

Closes the draft PR after rebasing on main (v1.19.0) and implementing all requested changes from review.