### PR TITLE
Add GitHub Sponsors funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: itayinbarr


### PR DESCRIPTION
Adds `.github/FUNDING.yml` pointing the sponsor button to my GitHub Sponsors page.

Note: the button is already live on this repo via the account-wide `itayinbarr/.github` default; this makes it explicit in-source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XjvEywYfzViAAGSnBTPBSe