### PR TITLE
Refresh MiniMax provider parameters in models.json

### DIFF
--- a/.pi/extensions/llama-cpp-provider/config.test.ts
+++ b/.pi/extensions/llama-cpp-provider/config.test.ts
@@ -98,6 +98,11 @@ describe("applyEnvOverrides", () => {
     const out = applyEnvOverrides(providers, { LMSTUDIO_BASE_URL: "http://127.0.0.1:5678/v1" });
     expect(out.lmstudio.baseUrl).toBe("http://127.0.0.1:5678/v1");
   });
+  it("MINIMAX_BASE_URL overrides minimax baseUrl (regional endpoint)", () => {
+    const providers = { minimax: sampleProvider("https://api.minimax.io/v1", "MiniMax-M3") };
+    const out = applyEnvOverrides(providers, { MINIMAX_BASE_URL: "https://api.minimaxi.com/v1" });
+    expect(out.minimax.baseUrl).toBe("https://api.minimaxi.com/v1");
+  });
   it("does not alter providers without a known env knob", () => {
     const providers = { custom: sampleProvider("http://file/v1", "m") };
     const out = applyEnvOverrides(providers, { LLAMACPP_BASE_URL: "http://env/v1" });
@@ -196,9 +201,32 @@ describe("shipped models.json", () => {
     expect(lmstudio.models.find((m) => m.id === "local-model")).toBeDefined();
   });
 
-  it("still registers llamacpp and ollama alongside lmstudio", () => {
+  it("still registers llamacpp and ollama alongside lmstudio and minimax", () => {
     const result = loadProviders(pkgRoot, {});
-    expect(Object.keys(result.providers).sort()).toEqual(["llamacpp", "lmstudio", "ollama"]);
+    expect(Object.keys(result.providers).sort()).toEqual(["llamacpp", "lmstudio", "minimax", "ollama"]);
+  });
+
+  it("registers minimax with the current 1M context, text/image/video, pricing, and thinking", () => {
+    const result = loadProviders(pkgRoot, {});
+    const minimax = result.providers.minimax;
+    expect(minimax, "minimax provider should be present in shipped models.json").toBeDefined();
+    expect(minimax.api).toBe("openai-completions");
+    expect(minimax.baseUrl).toBe("https://api.minimax.io/v1");
+    expect(minimax.apiKey).toBe("MINIMAX_API_KEY");
+
+    const m3 = minimax.models.find((m) => m.id === "MiniMax-M3");
+    expect(m3, "MiniMax-M3 should be registered").toBeDefined();
+    expect(m3!.contextWindow).toBe(1000000);
+    expect(m3!.input).toEqual(["text", "image", "video"]);
+    expect(m3!.cost).toEqual({ input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 });
+    expect(m3!.thinking).toEqual(["adaptive", "disabled"]);
+
+    const m27 = minimax.models.find((m) => m.id === "MiniMax-M2.7");
+    expect(m27, "MiniMax-M2.7 should be registered").toBeDefined();
+    expect(m27!.contextWindow).toBe(204800);
+    expect(m27!.input).toEqual(["text"]);
+    expect(m27!.cost).toEqual({ input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 });
+    expect(m27!.thinking).toEqual(["always_on"]);
   });
 });
 

--- a/.pi/extensions/llama-cpp-provider/config.ts
+++ b/.pi/extensions/llama-cpp-provider/config.ts
@@ -8,7 +8,7 @@
 //         "api": "openai-completions",
 //         "baseUrl": "http://...",
 //         "apiKey": "ENV_VAR_NAME",
-//         "models": [ { id, name, reasoning, input, contextWindow, maxTokens, cost }, ... ]
+//         "models": [ { id, name, reasoning, input, contextWindow, maxTokens, cost, thinking? }, ... ]
 //       }, ...
 //     }
 //   }
@@ -20,10 +20,14 @@ export interface ProviderModelEntry {
   id: string;
   name: string;
   reasoning: boolean;
-  input: ("text" | "image")[];
+  input: ("text" | "image" | "video")[];
   contextWindow: number;
   maxTokens: number;
   cost: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  /** Thinking modes the model supports, e.g. ["adaptive", "disabled"] or
+   *  ["always_on"]. Optional; passed through to pi's registerProvider
+   *  verbatim so the model registry can advertise the current modes. */
+  thinking?: string[];
 }
 
 export interface ProviderEntry {
@@ -46,11 +50,13 @@ export interface LoadResult {
 /** Provider env knob: if set, overrides the provider's baseUrl. Originally a
  *  back-compat shim for the two providers we shipped before the data-driven
  *  refactor; kept as the per-provider env-override pattern for any provider
- *  whose baseUrl changes between deployments. */
+ *  whose baseUrl changes between deployments (e.g. the regional endpoint
+ *  override for cloud providers whose baseUrl differs by region). */
 const LEGACY_BASE_URL_ENV: Record<string, string> = {
   llamacpp: "LLAMACPP_BASE_URL",
   ollama: "OLLAMA_BASE_URL",
   lmstudio: "LMSTUDIO_BASE_URL",
+  minimax: "MINIMAX_BASE_URL",
 };
 
 /** Resolution order for the user-override file. First existing path wins. */
@@ -96,7 +102,7 @@ export function fillModelDefaults(m: any, providerName: string, index: number): 
   const defaults = {
     name: m.id,
     reasoning: false,
-    input: ["text"] as ("text" | "image")[],
+    input: ["text"] as ("text" | "image" | "video")[],
     contextWindow: 32768,
     maxTokens: 4096,
     cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/.pi/extensions/llama-cpp-provider/index.ts
+++ b/.pi/extensions/llama-cpp-provider/index.ts
@@ -68,11 +68,15 @@ export default async function (pi: ExtensionAPI) {
       }
     }
 
+    // pi's ProviderModelConfig.input is typed ("text"|"image")[], but the
+    // registerProvider path stores model entries verbatim (see config.ts), so
+    // we cast through to forward the full modality list (e.g. "video") to the
+    // registry for providers whose current catalog advertises it.
     pi.registerProvider(name, {
       baseUrl: entry.baseUrl,
       apiKey: entry.apiKey,
       api: entry.api,
-      models,
+      models: models as unknown as Parameters<typeof pi.registerProvider>[1]["models"],
     });
 
     if (name === "llamacpp") {
@@ -113,7 +117,7 @@ export default async function (pi: ExtensionAPI) {
         baseUrl: lc.baseUrl,
         apiKey: lc.apiKey,
         api: lc.api,
-        models: lc.models,
+        models: lc.models as unknown as Parameters<typeof pi.registerProvider>[1]["models"],
       });
 
       const from = change.from !== undefined ? formatContextWindow(change.from) : "?";

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ export LMSTUDIO_API_KEY=noop
 
 `LLAMACPP_BASE_URL`, `OLLAMA_BASE_URL`, and `LMSTUDIO_BASE_URL` override the defaults (`http://127.0.0.1:8888/v1`, `http://127.0.0.1:11434/v1`, `http://127.0.0.1:1234/v1`).
 
-For cloud providers, set the standard env (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) and pi will discover it.
+For cloud providers, set the standard env (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) and pi will discover it. The shipped `models.json` also declares a `minimax` provider against the OpenAI-compatible endpoint (`https://api.minimax.io/v1`); export `MINIMAX_API_KEY` and pick a model with `little-coder --model minimax/MiniMax-M3`. `MINIMAX_BASE_URL` overrides the endpoint (e.g. `https://api.minimaxi.com/v1` for the CN region).
 
 ## Local model setup (optional)
 
@@ -248,7 +248,7 @@ Example — switch the llama.cpp port and bump `qwen3.6-35b-a3b` to a 150K conte
 
 Then verify with `little-coder --list-models` — you should see your overridden entry.
 
-`LLAMACPP_BASE_URL`, `OLLAMA_BASE_URL`, and `LMSTUDIO_BASE_URL` env vars still beat both files for those three providers.
+`LLAMACPP_BASE_URL`, `OLLAMA_BASE_URL`, `LMSTUDIO_BASE_URL`, and `MINIMAX_BASE_URL` env vars still beat both files for those providers.
 
 ### Any OpenAI-compatible server (e.g. MLX / omlx)
 
@@ -422,7 +422,7 @@ little-coder/
 │       ├── plan-mode/              # alt+p "research → ask → plan" flow (sub-coders + clarifying questions → written plan)
 │       ├── subagent/              # `dispatch` tool: isolated read/browse-only sub-coders + live tracker (spawn.ts engine)
 │       ├── prompt-history/         # up-arrow recall of recent prompts (from an empty input)
-│       ├── llama-cpp-provider/     # data-driven provider registration from models.json — ships llamacpp, ollama, lmstudio (+ user override file)
+│       ├── llama-cpp-provider/     # data-driven provider registration from models.json — ships llamacpp, ollama, lmstudio, minimax (+ user override file)
 │       ├── write-guard/            # Write refuses on existing files; rewrites root-bare /foo.md paths to cwd
 │       ├── read-guard/             # trims a Read that would overflow the context window to its first 30 lines + a search-instead directive
 │       ├── read-guard-edit/        # Edit refuses until the file has been Read this session

--- a/models.json
+++ b/models.json
@@ -66,6 +66,33 @@
           "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
         }
       ]
+    },
+    "minimax": {
+      "api": "openai-completions",
+      "baseUrl": "https://api.minimax.io/v1",
+      "apiKey": "MINIMAX_API_KEY",
+      "models": [
+        {
+          "id": "MiniMax-M3",
+          "name": "MiniMax-M3",
+          "reasoning": true,
+          "input": ["text", "image", "video"],
+          "contextWindow": 1000000,
+          "maxTokens": 4096,
+          "cost": { "input": 0.6, "output": 2.4, "cacheRead": 0.12, "cacheWrite": 0 },
+          "thinking": ["adaptive", "disabled"]
+        },
+        {
+          "id": "MiniMax-M2.7",
+          "name": "MiniMax-M2.7",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 204800,
+          "maxTokens": 4096,
+          "cost": { "input": 0.3, "output": 1.2, "cacheRead": 0.06, "cacheWrite": 0.375 },
+          "thinking": ["always_on"]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Reason: parameter-refresh — override the catalog MiniMax entries with the current 1M context, text/image/video input, OpenAI-compatible endpoint, and current pricing/thinking via the data-driven registerProvider extension.

## Changes

- **models.json**: add a `minimax` provider entry backed by the OpenAI-compatible endpoint (`https://api.minimax.io/v1`, `MINIMAX_API_KEY`). Registers `MiniMax-M3` (1,000,000-token context, text/image/video input, $0.6/$2.4/$0.12 per million input/output/cache-read tokens, adaptive/disabled thinking) and `MiniMax-M2.7` (204,800-token context, text input, $0.3/$1.2/$0.06/$0.375 pricing, always-on thinking).
- **.pi/extensions/llama-cpp-provider/config.ts**: widen `ProviderModelEntry.input` to `("text" | "image" | "video")[]` so the registry advertises the current video modality, add an optional `thinking?: string[]` field that passes through to `registerProvider`, and add `minimax: "MINIMAX_BASE_URL"` to the per-provider env-override map so the regional CN endpoint (`https://api.minimaxi.com/v1`) can be selected via `MINIMAX_BASE_URL`.
- **.pi/extensions/llama-cpp-provider/index.ts**: cast the model list at the `pi.registerProvider` boundary so the wider modality list (including `video`) forwards to the verbatim registry despite pi's narrower `ProviderModelConfig.input` type.
- **.pi/extensions/llama-cpp-provider/config.test.ts**: update the shipped-provider list assertion to include `minimax`, add assertions for the MiniMax-M3 and MiniMax-M2.7 context window, input modalities, pricing, and thinking modes, and add a `MINIMAX_BASE_URL` env-override test.
- **README.md**: document the `minimax` provider, `MINIMAX_API_KEY`, and the `MINIMAX_BASE_URL` regional override alongside the existing provider docs.

## Checks

- `npx tsc --noEmit` — passes.
- `npx vitest run .pi/extensions/llama-cpp-provider/` — 51/51 tests pass (config + swap-reprobe suites).
- `npx vitest run` — the full suite shows 4 pre-existing failures (glob, launcher, browser live-integration, prompt-history) that also fail on the clean `origin/main` baseline and are unrelated to this diff (environment/dependency/Node-version issues, not provider-config code).
