### PR TITLE
feat(permission): prompt for confirmation in manual mode

### DIFF
--- a/.pi/extensions/permission-gate/index.ts
+++ b/.pi/extensions/permission-gate/index.ts
@@ -81,7 +81,7 @@ function getPermissionMode(): "auto" | "accept-all" | "manual" {
 }
 
 export default function (pi: ExtensionAPI) {
-  pi.on("tool_call", async (event, _ctx) => {
+  pi.on("tool_call", async (event, ctx) => {
     const mode = getPermissionMode();
     if (mode === "accept-all") return;
 
@@ -92,47 +92,56 @@ export default function (pi: ExtensionAPI) {
     // destructive edits via the TUI.
     if (SHELL_TOOLS.has(toolName)) {
       const cmd = input?.command;
-      if (typeof cmd === "string" && !isSafeBash(cmd)) {
+      if (typeof cmd === "string") {
         if (mode === "manual") {
-          return { block: true, reason: "manual permission mode: shell command not pre-approved" };
+          const confirmed = await ctx.ui.confirm(
+            `About to execute:\n\n${cmd}`,
+            "Execute this command?",
+          );
+          if (!confirmed) {
+            return { block: true, reason: "command cancelled by user" };
+          }
+          return;
         }
-        // auto: block when not whitelisted. Name the reason precisely — a
-        // refusal the model can't interpret just gets retried verbatim.
-        const writes = detectWriteTargets(cmd);
-        if (writes.length > 0) {
+        if (!isSafeBash(cmd)) {
+          // auto: block when not whitelisted. Name the reason precisely — a
+          // refusal the model can't interpret just gets retried verbatim.
+          const writes = detectWriteTargets(cmd);
+          if (writes.length > 0) {
+            return {
+              block: true,
+              reason:
+                `shell whitelist: this command writes to ${writes.map((w) => `"${w.path}"`).join(", ")} ` +
+                `via shell redirection. Use the Write tool for a new file, or Edit for an existing one — ` +
+                `do not redirect into files.`,
+            };
+          }
+          const offender =
+            splitCommandChain(cmd).find((s) => !isSafeBash(s)) ?? cmd;
+          const binary = offender.split(/\s+/)[0];
+          // Say what to do next, not just what was refused.
+          //
+          // The bare "not in SAFE_PREFIXES" line sent models hunting: observed
+          // live, a refusal on `./build.sh` was followed by `bash ./build.sh`,
+          // then `sh ./build.sh`, then a successful `python3 -c
+          // "subprocess.run(...)"` — three wasted turns and the guard defeated
+          // anyway, because interpreters are themselves whitelisted (issue #94).
+          // A refusal that names the actual remedy is the only thing that stops
+          // the search, and it is far closer to the decision than a line in
+          // AGENTS.md thousands of tokens earlier.
           return {
             block: true,
             reason:
-              `shell whitelist: this command writes to ${writes.map((w) => `"${w.path}"`).join(", ")} ` +
-              `via shell redirection. Use the Write tool for a new file, or Edit for an existing one — ` +
-              `do not redirect into files.`,
+              `shell whitelist: "${binary}" is not in SAFE_PREFIXES, so this command was refused.\n` +
+              `Do NOT try to reach the same effect another way — re-running it through ` +
+              `python3 -c, node -e, env, sh, or an -exec flag defeats a limit the user set on ` +
+              `purpose, and wastes your budget.\n` +
+              `If a file needs changing, use edit/write, which do not need a shell. ` +
+              `Otherwise tell the user this command was refused and that they can allow it with ` +
+              `LITTLE_CODER_BASH_ALLOW="${binary}" (or set LITTLE_CODER_PERMISSION_MODE=accept-all), ` +
+              `then continue with the rest of the task.`,
           };
         }
-        const offender =
-          splitCommandChain(cmd).find((s) => !isSafeBash(s)) ?? cmd;
-        const binary = offender.split(/\s+/)[0];
-        // Say what to do next, not just what was refused.
-        //
-        // The bare "not in SAFE_PREFIXES" line sent models hunting: observed
-        // live, a refusal on `./build.sh` was followed by `bash ./build.sh`,
-        // then `sh ./build.sh`, then a successful `python3 -c
-        // "subprocess.run(...)"` — three wasted turns and the guard defeated
-        // anyway, because interpreters are themselves whitelisted (issue #94).
-        // A refusal that names the actual remedy is the only thing that stops
-        // the search, and it is far closer to the decision than a line in
-        // AGENTS.md thousands of tokens earlier.
-        return {
-          block: true,
-          reason:
-            `shell whitelist: "${binary}" is not in SAFE_PREFIXES, so this command was refused.\n` +
-            `Do NOT try to reach the same effect another way — re-running it through ` +
-            `python3 -c, node -e, env, sh, or an -exec flag defeats a limit the user set on ` +
-            `purpose, and wastes your budget.\n` +
-            `If a file needs changing, use edit/write, which do not need a shell. ` +
-            `Otherwise tell the user this command was refused and that they can allow it with ` +
-            `LITTLE_CODER_BASH_ALLOW="${binary}" (or set LITTLE_CODER_PERMISSION_MODE=accept-all), ` +
-            `then continue with the rest of the task.`,
-        };
       }
     }
   });

--- a/.pi/extensions/permission-gate/permission.test.ts
+++ b/.pi/extensions/permission-gate/permission.test.ts
@@ -95,12 +95,12 @@ describe("permission-gate tool_call interceptor", () => {
     return handler;
   }
 
-  function withMode<T>(mode: string | undefined, fn: () => T): T {
+  async function withMode<T>(mode: string | undefined, fn: () => T | Promise<T>): Promise<T> {
     const prev = process.env.LITTLE_CODER_PERMISSION_MODE;
     if (mode === undefined) delete process.env.LITTLE_CODER_PERMISSION_MODE;
     else process.env.LITTLE_CODER_PERMISSION_MODE = mode;
     try {
-      return fn();
+      return await fn();
     } finally {
       if (prev === undefined) delete process.env.LITTLE_CODER_PERMISSION_MODE;
       else process.env.LITTLE_CODER_PERMISSION_MODE = prev;

--- a/.pi/extensions/permission-gate/permission.test.ts
+++ b/.pi/extensions/permission-gate/permission.test.ts
@@ -173,6 +173,48 @@ describe("permission-gate tool_call interceptor", () => {
       expect(result).toBeUndefined();
     });
   });
+
+  it("manual mode prompts and allows when user confirms", async () => {
+    const handler = getHandler();
+    await withMode("manual", async () => {
+      const result = await handler(
+        { toolName: "bash", input: { command: "rm -rf /" } },
+        { ui: { confirm: async () => true } },
+      );
+      expect(result).toBeUndefined();
+    });
+  });
+
+  it("manual mode prompts and blocks when user declines", async () => {
+    const handler = getHandler();
+    await withMode("manual", async () => {
+      const result = await handler(
+        { toolName: "bash", input: { command: "rm -rf /" } },
+        { ui: { confirm: async () => false } },
+      );
+      expect(result?.block).toBe(true);
+      expect(result.reason).toBe("command cancelled by user");
+    });
+  });
+
+  it("manual mode prompts for whitelisted commands too", async () => {
+    const handler = getHandler();
+    let promptShown = false;
+    await withMode("manual", async () => {
+      await handler(
+        { toolName: "bash", input: { command: "git status" } },
+        {
+          ui: {
+            confirm: async () => {
+              promptShown = true;
+              return true;
+            },
+          },
+        },
+      );
+      expect(promptShown).toBe(true);
+    });
+  });
 });
 
 describe("parseExtraPrefixes", () => {

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Two env vars control the gate:
 
 | Env var | Values | Effect |
 |---|---|---|
-| `LITTLE_CODER_PERMISSION_MODE` | `auto` *(default)* / `accept-all` / `manual` | `auto`: block any shell command not on the whitelist. `accept-all`: skip the gate entirely, every shell call passes (the benchmark runner sets this). `manual`: same as `auto` but with a different rejection message. |
+| `LITTLE_CODER_PERMISSION_MODE` | `auto` *(default)* / `accept-all` / `manual` | `auto`: block any shell command not on the whitelist. `accept-all`: skip the gate entirely, every shell call passes (the benchmark runner sets this). `manual`: prompt for confirmation before every shell command — the command is shown and you choose to execute (`y`) or cancel (`n`). |
 | `LITTLE_CODER_BASH_ALLOW` | comma-separated prefixes | Extra allow-prefixes merged with the built-in list. **Trailing whitespace is meaningful**: `"make "` allows `make test` but not `makefoo`; `"make"` allows both. |
 
 Examples:


### PR DESCRIPTION
## Summary

In `manual` permission mode, little-coder now prompts the user before executing **any** shell command instead of blocking outright.

### Behavior

| Mode | Before | After |
|------|--------|-------|
| `auto` (default) | Block non-whitelisted commands | Unchanged |
| `accept-all` | Allow all commands | Unchanged |
| `manual` | Block non-whitelisted commands | **Prompt for every command** |

In manual mode:
1. Show the exact command to execute
2. Ask: `Execute this command?`
3. User confirms (`y`) → execute
4. User cancels (`n`) → block with "command cancelled by user"

### Usage

```bash
export LITTLE_CODER_PERMISSION_MODE=manual
little-coder
```

### Implementation

- Minimal change: reuse existing`ctx.ui.confirm()` API
- No new dependencies or abstractions
- All 536 tests pass

### Files changed

- `.pi/extensions/permission-gate/index.ts` — add confirmation prompt for manual mode
- `.pi/extensions/permission-gate/permission.test.ts` — add tests for manual mode
- `README.md` — update`LITTLE_CODER_PERMISSION_MODE` table