### PR TITLE
Fix correctness bugs: orphaned sub-coders, dropped tool calls, dead checkpoint backup, unvalidated update version

### DIFF
--- a/.pi/extensions/checkpoint/checkpoint.test.ts
+++ b/.pi/extensions/checkpoint/checkpoint.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import setupCheckpoint, { checkpointPath, tracked } from "./index.ts";
+
+describe("checkpointPath", () => {
+  it("reads the `path` key (current pi write/edit)", () => {
+    expect(checkpointPath({ path: "/a/b.ts" })).toBe("/a/b.ts");
+  });
+  it("falls back to the legacy `file_path` key", () => {
+    expect(checkpointPath({ file_path: "/a/c.ts" })).toBe("/a/c.ts");
+  });
+  it("prefers `path` when both are present", () => {
+    expect(checkpointPath({ path: "/p", file_path: "/f" })).toBe("/p");
+  });
+  it("returns undefined when neither is a string", () => {
+    expect(checkpointPath({})).toBeUndefined();
+    expect(checkpointPath({ path: 5 as unknown as string })).toBeUndefined();
+  });
+});
+
+function setup() {
+  const handlers: Record<string, (...args: any[]) => any> = {};
+  const pi = {
+    on(name: string, h: (...args: any[]) => any) {
+      handlers[name] = h;
+    },
+  };
+  setupCheckpoint(pi as any);
+  return handlers;
+}
+
+// homedir() honors $HOME on POSIX, so pointing it at a tmpdir isolates the
+// ~/.little-coder/checkpoints/ writes the backup net makes.
+describe("checkpoint pre-edit backup net", () => {
+  let home: string;
+  let origHome: string | undefined;
+  beforeEach(() => {
+    origHome = process.env.HOME;
+    home = mkdtempSync(join(tmpdir(), "ckpt-"));
+    process.env.HOME = home;
+    tracked.clear();
+  });
+  afterEach(() => {
+    if (origHome === undefined) delete process.env.HOME;
+    else process.env.HOME = origHome;
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("snapshots a file modified via the `path` key (regression: previously never fired)", async () => {
+    const h = setup();
+    const target = join(home, "src.txt");
+    writeFileSync(target, "original");
+    await h.session_start({}, { sessionManager: { getSessionFile: () => "/x/sess-123.json" } });
+    await h.tool_call({ toolName: "write", input: { path: target, content: "new" } });
+
+    const dir = join(home, ".little-coder", "checkpoints", "sess-123.json");
+    expect(existsSync(dir)).toBe(true);
+    expect(readdirSync(dir).length).toBe(1);
+  });
+
+  it("also snapshots via the legacy `file_path` key", async () => {
+    const h = setup();
+    const target = join(home, "src2.txt");
+    writeFileSync(target, "orig");
+    await h.session_start({}, { sessionManager: { getSessionFile: () => "/x/sess-9.json" } });
+    await h.tool_call({ toolName: "Edit", input: { file_path: target, edits: [] } });
+
+    expect(existsSync(join(home, ".little-coder", "checkpoints", "sess-9.json"))).toBe(true);
+  });
+
+  it("ignores tool calls that carry no path", async () => {
+    const h = setup();
+    await h.session_start({}, { sessionManager: { getSessionFile: () => "/x/sess-0.json" } });
+    await h.tool_call({ toolName: "write", input: { content: "no path here" } });
+    expect(existsSync(join(home, ".little-coder", "checkpoints", "sess-0.json"))).toBe(false);
+  });
+});

--- a/.pi/extensions/checkpoint/index.ts
+++ b/.pi/extensions/checkpoint/index.ts
@@ -8,7 +8,19 @@ import { homedir } from "node:os";
 // a file already tracked this session). Backups land in
 // ~/.little-coder/checkpoints/<session>/.
 
-const tracked = new Map<string, Set<string>>(); // sessionId -> absolute paths
+export const tracked = new Map<string, Set<string>>(); // sessionId -> absolute paths
+
+// Read whichever key carries the destination path. pi's built-in `write`/`edit`
+// use `path`; older little-coder builds and some prompts use `file_path`. We
+// accept both so the pre-edit backup fires regardless of which write
+// implementation is in play — write-guard and read-guard-edit already do this,
+// and keying only on `file_path` meant the snapshot silently never ran for the
+// current pi tools (whose input uses `path`).
+export function checkpointPath(input: Record<string, unknown>): string | undefined {
+  if (typeof input?.path === "string") return input.path;
+  if (typeof input?.file_path === "string") return input.file_path;
+  return undefined;
+}
 
 function checkpointDir(sessionId: string): string {
   const dir = join(homedir(), ".little-coder", "checkpoints", sessionId);
@@ -58,8 +70,8 @@ export default function (pi: ExtensionAPI) {
       return;
     }
     const input: any = (event as any).input ?? (event as any).args;
-    const filePath = input?.file_path;
-    if (typeof filePath === "string") {
+    const filePath = checkpointPath(input ?? {});
+    if (filePath) {
       backupIfNeeded(currentSessionId, filePath);
     }
   });

--- a/.pi/extensions/knowledge-inject/index.ts
+++ b/.pi/extensions/knowledge-inject/index.ts
@@ -14,7 +14,7 @@ import { injectionResult, makeDedupe } from "../_shared/inject.ts";
 // Like skill-inject, the selected entries ride in as a tail message rather
 // than a system-prompt append (issue #73 — see _shared/inject.ts).
 
-interface KnowledgeEntry {
+export interface KnowledgeEntry {
   topic: string;
   body: string;
   tokenCost: number;
@@ -26,7 +26,7 @@ const entries = new Map<string, KnowledgeEntry>();
 const cache = new Map<string, string>();
 let loaded = false;
 
-const MIN_SCORE_THRESHOLD = 2.0;
+export const MIN_SCORE_THRESHOLD = 2.0;
 const PER_ENTRY_CAP = 150;
 
 function dirs(): string[] {
@@ -62,7 +62,7 @@ function loadEntries(): void {
 }
 
 // ── Scoring (word=1.0, bigram/phrase=2.0) ───────────────────────────────
-function scoreEntry(userText: string, e: KnowledgeEntry): number {
+export function scoreEntry(userText: string, e: KnowledgeEntry): number {
   if (e.keywords.length === 0) return 0;
   const textLower = userText.toLowerCase();
   const words = new Set(textLower.split(/\s+/).filter(Boolean));

--- a/.pi/extensions/knowledge-inject/scoring.test.ts
+++ b/.pi/extensions/knowledge-inject/scoring.test.ts
@@ -3,49 +3,46 @@ import { readFileSync, existsSync, readdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { parseSkillFile } from "../skill-inject/frontmatter.ts";
+import { scoreEntry, MIN_SCORE_THRESHOLD, type KnowledgeEntry } from "./index.ts";
 
-// Duplicate scoring so tests can exercise it as a pure function.
-function scoreEntry(userText: string, keywords: string[]): number {
-  if (keywords.length === 0) return 0;
-  const textLower = userText.toLowerCase();
-  const words = new Set(textLower.split(/\s+/).filter(Boolean));
-  let score = 0;
-  for (const kw of keywords) {
-    if (kw.includes(" ")) {
-      if (textLower.includes(kw)) score += 2.0;
-    } else {
-      if (words.has(kw)) score += 1.0;
-    }
-  }
-  return score;
+// Exercise the REAL scoreEntry (imported above), not a hand-copied duplicate —
+// a regression in the production scorer must fail this test. Only `keywords`
+// affects the score, so the other KnowledgeEntry fields are inert here.
+function entry(keywords: string[]): KnowledgeEntry {
+  return { topic: "t", body: "b", tokenCost: 0, keywords, requiresTools: [] };
 }
 
 describe("knowledge entry scoring", () => {
   it("scores single word matches at 1.0 each", () => {
-    expect(scoreEntry("find the bucket", ["bucket"])).toBe(1.0);
-    expect(scoreEntry("find the bucket and pour", ["bucket", "pour"])).toBe(2.0);
+    expect(scoreEntry("find the bucket", entry(["bucket"]))).toBe(1.0);
+    expect(scoreEntry("find the bucket and pour", entry(["bucket", "pour"]))).toBe(2.0);
   });
 
   it("scores bigram/phrase matches at 2.0 each", () => {
-    expect(scoreEntry("minimum moves to solve", ["minimum moves"])).toBe(2.0);
-    expect(scoreEntry("state space search", ["state space"])).toBe(2.0);
+    expect(scoreEntry("minimum moves to solve", entry(["minimum moves"]))).toBe(2.0);
+    expect(scoreEntry("state space search", entry(["state space"]))).toBe(2.0);
   });
 
   it("combines word + bigram scores", () => {
     const kw = ["bucket", "minimum moves", "pour"];
     // "bucket" word (1.0) + "minimum moves" phrase (2.0) + "pour" word (1.0) = 4.0
-    expect(scoreEntry("bucket pouring problem with minimum moves and pour", kw)).toBe(4.0);
+    expect(scoreEntry("bucket pouring problem with minimum moves and pour", entry(kw))).toBe(4.0);
   });
 
   it("does not match partial words", () => {
     // 'bucket' shouldn't match 'buckets' because the scorer tokenizes on whitespace
-    expect(scoreEntry("many buckets here", ["bucket"])).toBe(0);
+    expect(scoreEntry("many buckets here", entry(["bucket"]))).toBe(0);
+  });
+
+  it("scores 0 for an entry with no keywords", () => {
+    expect(scoreEntry("anything at all", entry([]))).toBe(0);
   });
 
   it("threshold at 2.0 requires at least two signals", () => {
     // The extension's MIN_SCORE_THRESHOLD = 2.0 means one word isn't enough
-    expect(scoreEntry("find bucket", ["bucket", "pour"])).toBeLessThan(2.0);
-    expect(scoreEntry("bucket pour together", ["bucket", "pour"])).toBeGreaterThanOrEqual(2.0);
+    expect(MIN_SCORE_THRESHOLD).toBe(2.0);
+    expect(scoreEntry("find bucket", entry(["bucket", "pour"]))).toBeLessThan(MIN_SCORE_THRESHOLD);
+    expect(scoreEntry("bucket pour together", entry(["bucket", "pour"]))).toBeGreaterThanOrEqual(MIN_SCORE_THRESHOLD);
   });
 });
 

--- a/.pi/extensions/output-parser/parser.test.ts
+++ b/.pi/extensions/output-parser/parser.test.ts
@@ -1,5 +1,35 @@
 import { describe, it, expect } from "vitest";
-import { repairJson, parseTextToolCalls, parseLiquidToolCalls, escapeNewlinesInJsonStrings } from "./parser.ts";
+import { repairJson, parseTextToolCalls, parseLiquidToolCalls, escapeNewlinesInJsonStrings, firstBalancedObject } from "./parser.ts";
+
+describe("firstBalancedObject", () => {
+  it("returns the OUTER object even when it nests further objects", () => {
+    const s = '{"name":"Write","input":{"a":1}}';
+    expect(firstBalancedObject(s)).toBe(s);
+  });
+  it("ignores braces that live inside string values", () => {
+    expect(firstBalancedObject('{"a":"}"}')).toBe('{"a":"}"}');
+  });
+  it("stops at the first fully balanced object", () => {
+    expect(firstBalancedObject('{"a":1} {"b":2}')).toBe('{"a":1}');
+  });
+  it("returns null when nothing balances", () => {
+    expect(firstBalancedObject("{unterminated")).toBeNull();
+    expect(firstBalancedObject("no braces here")).toBeNull();
+  });
+});
+
+describe("repairJson recovers a nested call before trailing garbage (LOGIC-001)", () => {
+  it("keeps the outer call, not the inner input fragment, when text follows it", () => {
+    const out = repairJson('{"name":"Write","input":{"path":"/a"}}\nSorry, retry: {broken');
+    expect(out.name).toBe("Write");
+    expect(out.input).toEqual({ path: "/a" });
+  });
+  it("parses a whole tool call whose string value contains a brace", () => {
+    const out = repairJson('{"name":"Bash","input":{"command":"echo {"}} and then junk');
+    expect(out.name).toBe("Bash");
+    expect((out.input as Record<string, unknown>).command).toBe("echo {");
+  });
+});
 
 describe("repairJson", () => {
   it("direct parse on valid JSON", () => {

--- a/.pi/extensions/output-parser/parser.ts
+++ b/.pi/extensions/output-parser/parser.ts
@@ -33,6 +33,33 @@ export function escapeNewlinesInJsonStrings(text: string): string {
   return out.join("");
 }
 
+/** The first brace-balanced `{…}` substring of `s`, tracking nesting depth and
+ *  string quoting/escapes, or null if none closes. Unlike a `/\{[^{}]*\}/`
+ *  regex it returns the OUTER object even when it nests further objects — so a
+ *  valid tool call like `{"name":"Write","input":{…}}` isn't lost to its inner
+ *  `input` fragment when trailing text follows it — and a `}` inside a string
+ *  value doesn't prematurely close the match. */
+export function firstBalancedObject(s: string): string | null {
+  const start = s.indexOf("{");
+  if (start < 0) return null;
+  let depth = 0;
+  let quote: string | null = null;
+  let esc = false;
+  for (let i = start; i < s.length; i++) {
+    const c = s[i];
+    if (quote) {
+      if (esc) esc = false;
+      else if (c === "\\") esc = true;
+      else if (c === quote) quote = null;
+      continue;
+    }
+    if (c === "'" || c === '"') quote = c;
+    else if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return s.slice(start, i + 1);
+  }
+  return null;
+}
+
 export function repairJson(raw: string): Record<string, unknown> {
   const trimmed = raw.trim();
   if (!trimmed) return {};
@@ -61,11 +88,12 @@ export function repairJson(raw: string): Record<string, unknown> {
   try {
     return JSON.parse(fixed);
   } catch {}
-  // 6. extract first JSON object
-  const m = fixed.match(/\{[^{}]*\}/);
-  if (m) {
+  // 6. extract the first brace-balanced object (nesting- and quote-aware, so a
+  //    valid call isn't lost to an inner fragment when trailing text follows).
+  const obj = firstBalancedObject(fixed);
+  if (obj) {
     try {
-      return JSON.parse(m[0]);
+      return JSON.parse(obj);
     } catch {}
   }
   return { _raw: raw };

--- a/.pi/extensions/subagent/spawn.test.ts
+++ b/.pi/extensions/subagent/spawn.test.ts
@@ -1,14 +1,57 @@
 import { describe, it, expect } from "vitest";
+import { spawn } from "node:child_process";
 import {
   buildChildEnv,
   defaultConcurrency,
   getFinalText,
   resolveLauncher,
+  scheduleForceKill,
   summarizeActivity,
   truncateReport,
   SUBCODER_ALLOWED_TOOLS,
   type SubCoderResult,
 } from "./spawn.ts";
+
+describe("scheduleForceKill", () => {
+  it("SIGKILLs a child that ignores SIGTERM (proc.killed would have blocked it)", async () => {
+    // Trap SIGTERM and stay alive — only SIGKILL can end this child. Print
+    // "ready" AFTER registering the handler so the parent doesn't race the
+    // SIGTERM in before the trap is installed (which would kill it by default).
+    const child = spawn(process.execPath, [
+      "-e",
+      "process.on('SIGTERM',()=>{});console.log('ready');setInterval(()=>{},1000)",
+    ]);
+    await new Promise<void>((r) => {
+      child.stdout.on("data", (d) => {
+        if (d.toString().includes("ready")) r();
+      });
+    });
+
+    child.kill("SIGTERM");
+    // Node flips `killed` true on dispatch even though the child is still alive —
+    // this is exactly the condition that made the old `if (!proc.killed)` dead.
+    expect(child.killed).toBe(true);
+
+    let exited = false;
+    child.once("exit", () => (exited = true));
+    scheduleForceKill(child, () => exited, 50);
+
+    const signal = await new Promise<NodeJS.Signals | null>((r) =>
+      child.once("exit", (_code, sig) => r(sig)),
+    );
+    expect(signal).toBe("SIGKILL");
+  });
+
+  it("does not force-kill a child that has already exited", async () => {
+    let killed = false;
+    const fake = { kill: () => (killed = true) };
+    await new Promise((r) => {
+      scheduleForceKill(fake as any, () => true, 5);
+      setTimeout(r, 30);
+    });
+    expect(killed).toBe(false);
+  });
+});
 
 const base: SubCoderResult = {
   id: "1",

--- a/.pi/extensions/subagent/spawn.ts
+++ b/.pi/extensions/subagent/spawn.ts
@@ -17,10 +17,32 @@
 // dispatch) entirely through environment variables the existing gates already
 // honor — see buildChildEnv().
 
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+
+/**
+ * Escalate to SIGKILL `delayMs` after a SIGTERM, unless the child has already
+ * exited. The gate is the caller's `hasExited()` — deliberately NOT
+ * `proc.killed`, which Node sets true on signal *dispatch* (not on actual
+ * termination), which made the previous `if (!proc.killed)` escalation
+ * unreachable and let a SIGTERM-ignoring child leak as an orphan. Returns the
+ * timer so callers may clear it. Never throws (the process may already be gone).
+ */
+export function scheduleForceKill(
+  proc: Pick<ChildProcess, "kill">,
+  hasExited: () => boolean,
+  delayMs = 4000,
+): ReturnType<typeof setTimeout> {
+  return setTimeout(() => {
+    try {
+      if (!hasExited()) proc.kill("SIGKILL");
+    } catch {
+      /* ignore */
+    }
+  }, delayMs);
+}
 
 // Tools a sub-coder may use: read + search + browse online + read-only bash.
 // Enforced by the tool-gating extension in the child. Deliberately omits
@@ -330,6 +352,12 @@ async function runSubCoderOnce(opts: RunSubCoderOptions): Promise<SubCoderResult
     proc.stderr.on("data", (d) => {
       result.stderr += d.toString();
     });
+    // Tracks whether the child has actually exited. proc.killed is NOT this: Node
+    // sets proc.killed true the instant a signal is *dispatched*, not when the
+    // process dies, so gating the SIGKILL escalation on !proc.killed made it
+    // unreachable — a child that ignores SIGTERM was never force-killed and
+    // leaked as an orphan. The close/error handlers below flip this true.
+    let exited = false;
     // SIGTERM then SIGKILL — shared by the abort-signal and the watchdog timeout.
     const kill = () => {
       try {
@@ -337,13 +365,7 @@ async function runSubCoderOnce(opts: RunSubCoderOptions): Promise<SubCoderResult
       } catch {
         /* already gone */
       }
-      setTimeout(() => {
-        try {
-          if (!proc.killed) proc.kill("SIGKILL");
-        } catch {
-          /* ignore */
-        }
-      }, 4000);
+      scheduleForceKill(proc, () => exited);
     };
 
     // Watchdog: a child that hangs (e.g. a browser stuck on a page) must not
@@ -358,11 +380,13 @@ async function runSubCoderOnce(opts: RunSubCoderOptions): Promise<SubCoderResult
     }
 
     proc.on("close", (code) => {
+      exited = true;
       if (watchdog) clearTimeout(watchdog);
       if (buffer.trim()) processLine(buffer);
       resolveP(code ?? 0);
     });
     proc.on("error", (e) => {
+      exited = true;
       if (watchdog) clearTimeout(watchdog);
       result.stderr += String(e?.message ?? e);
       resolveP(1);
@@ -410,8 +434,8 @@ async function mapWithConcurrencyLimit<TIn, TOut>(
 }
 
 /**
- * Run several sub-coders with a concurrency cap (default 2 — a single local
- * backend is easily starved). `onUpdate` receives a fresh snapshot of all
+ * Run several sub-coders with a concurrency cap (default 1 — serial; a single
+ * local backend is easily starved, see defaultConcurrency). `onUpdate` receives a fresh snapshot of all
  * results whenever any child changes, which drives the live tracker.
  */
 export async function runSubCodersConcurrent(

--- a/bin/update-check.mjs
+++ b/bin/update-check.mjs
@@ -59,11 +59,26 @@ export function writeCache(latest, now = Date.now()) {
   }
 }
 
-// Compare semver strings. Only handles X.Y.Z[+pre]. Returns 1 if a > b,
+// Accept only a well-formed X.Y.Z[-prerelease] version. The npm registry always
+// serves valid semver, so this rejects nothing legitimate — it refuses a
+// malformed or hostile `latest` before it reaches compareSemver (which would do
+// NaN math on it) or the Windows self-update sink `cmd.exe /c npm install
+// little-coder@<latest>`, where a shell metacharacter in the version string
+// would otherwise be re-parsed by cmd.exe as a chained command.
+export function isSemver(v) {
+  return typeof v === "string" && /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(v);
+}
+
+// Compare semver strings. Only handles X.Y.Z[-pre]. Returns 1 if a > b,
 // -1 if a < b, 0 if equal. Pre-release suffixes are treated as < release.
 export function compareSemver(a, b) {
   const parse = (v) => {
-    const [core, pre] = String(v).split("-", 2);
+    // Split at the FIRST hyphen only: a prerelease tag may itself contain
+    // hyphens (`1.0.0-rc-1`), and split("-", 2) would truncate its tail.
+    const s = String(v);
+    const h = s.indexOf("-");
+    const core = h < 0 ? s : s.slice(0, h);
+    const pre = h < 0 ? "" : s.slice(h + 1);
     const parts = core.split(".").map((n) => parseInt(n, 10));
     return {
       major: parts[0] || 0,
@@ -91,7 +106,7 @@ async function fetchLatest() {
     const res = await fetch(REGISTRY, { signal: ctrl.signal });
     if (!res.ok) return null;
     const json = await res.json();
-    return typeof json?.version === "string" ? json.version : null;
+    return isSemver(json?.version) ? json.version : null;
   } catch {
     return null;
   } finally {

--- a/bin/update-check.test.mjs
+++ b/bin/update-check.test.mjs
@@ -8,11 +8,31 @@ import {
   readCache,
   writeCache,
   compareSemver,
+  isSemver,
   shouldSkip,
   promptTimeoutMs,
 } from "./update-check.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
+
+describe("isSemver", () => {
+  it("accepts well-formed X.Y.Z and prerelease versions", () => {
+    expect(isSemver("1.14.0")).toBe(true);
+    expect(isSemver("0.0.1")).toBe(true);
+    expect(isSemver("2.3.4-rc.1")).toBe(true);
+    expect(isSemver("2.3.4-rc-1")).toBe(true);
+  });
+  it("rejects non-semver and shell-metacharacter payloads", () => {
+    // Guards the Windows self-update sink `cmd.exe /c npm install little-coder@<v>`.
+    expect(isSemver("1.0")).toBe(false);
+    expect(isSemver("latest")).toBe(false);
+    expect(isSemver("1.0.0 & calc.exe")).toBe(false);
+    expect(isSemver("1.0.0; rm -rf /")).toBe(false);
+    expect(isSemver("1.0.0\ncalc")).toBe(false);
+    expect(isSemver(undefined)).toBe(false);
+    expect(isSemver(123)).toBe(false);
+  });
+});
 
 describe("compareSemver", () => {
   it("orders major / minor / patch correctly", () => {
@@ -33,6 +53,12 @@ describe("compareSemver", () => {
   it("tolerates short version strings", () => {
     expect(compareSemver("1.0", "1.0.0")).toBe(0);
     expect(compareSemver("1", "1.0.0")).toBe(0);
+  });
+
+  it("keeps the full prerelease tail past extra hyphens", () => {
+    // split('-', 2) truncated 'rc-2' → 'rc', making both sides compare equal.
+    expect(compareSemver("1.0.0-rc-2", "1.0.0-rc-1")).toBe(1);
+    expect(compareSemver("1.0.0-rc-1", "1.0.0-rc-2")).toBe(-1);
   });
 });
 


### PR DESCRIPTION

## Summary

A handful of correctness and hardening fixes found while auditing v1.14.0. Each is independent and
carries a test; the full suite passes (`549 pass / 10 skip`) and `npm run typecheck` is clean. Happy
to split this into separate PRs if you'd prefer to review them one at a time.

## Fixes

1. **`subagent/spawn.ts` — a sub-coder that ignores SIGTERM is never force-killed.**
   The watchdog's SIGKILL escalation was gated on `!proc.killed`, but Node sets `proc.killed` true
   the instant a signal is *dispatched*, not when the process exits — so after the SIGTERM the branch
   was unreachable and a hung child (the "browser stuck on a page" case the code comments cite) leaked
   as an orphan. Now tracks real exit via a local flag set on `close`/`error`; the escalation is
   extracted to `scheduleForceKill()` and gated on that. Test spawns a real SIGTERM-ignoring child and
   asserts SIGKILL actually lands.

2. **`checkpoint/index.ts` — pre-edit backup never fires for current pi.**
   It keyed only on `input.file_path`, but pi's built-in write/edit use `path` (write-guard and
   read-guard-edit already accept both). So the `~/.little-coder/checkpoints/` snapshot silently never
   wrote for normal operation. Added `checkpointPath()` accepting both keys; new test proves a
   `path`-keyed write now snapshots.

3. **`output-parser/parser.ts` — a valid tool call is dropped when trailing text follows it.**
   `repairJson`'s step-6 fallback `/\{[^{}]*\}/` grabs the first *brace-free* object, so a nested
   `{"name":…,"input":{…}}` followed by any stray `{` returned the inner `input` fragment (no `name`)
   and the call was silently discarded. Replaced with a quote/nesting-aware `firstBalancedObject()`
   that returns the outer object and doesn't truncate on a `}` inside a string. Tests cover both.

4. **`bin/update-check.mjs` — validate the registry version string.**
   `fetchLatest()` accepted any string as `version`; it flows into `compareSemver` (NaN math) and, on
   Windows, into `cmd.exe /c npm install little-coder@<latest>`, where a shell metacharacter would be
   re-parsed by cmd.exe. Added `isSemver()` and reject non-semver. The registry always serves valid
   semver, so nothing legitimate is rejected — this only closes the injection/NaN paths.

5. **`bin/update-check.mjs` — keep the full prerelease tail in `compareSemver`.**
   `split("-", 2)` truncated a multi-hyphen prerelease (`1.0.0-rc-1` → `rc`), losing the tail and
   mis-ordering. Split on the first hyphen only. Test added.

6. **`knowledge-inject/scoring.test.ts` — the test exercised a copy, not the real code.**
   It hand-copied a `scoreEntry` with a different signature, so a regression in the production scorer
   passed green. Exported the real `scoreEntry`/`MIN_SCORE_THRESHOLD` and rewrote the test to import
   and exercise them.

7. **`subagent/spawn.ts` — docstring said concurrency default is 2; it's 1 (serial).** Corrected.

## Testing

`npm run typecheck` clean · `npx vitest run` 549 pass / 10 skip (the 10 are the `LC_LIVE`-gated
live-model tests). New tests added for fixes 1–6.