### PR TITLE
feat(providers): add OrcaRouter as a named provider

### DIFF
--- a/.pi/extensions/llama-cpp-provider/config.test.ts
+++ b/.pi/extensions/llama-cpp-provider/config.test.ts
@@ -98,6 +98,11 @@ describe("applyEnvOverrides", () => {
     const out = applyEnvOverrides(providers, { LMSTUDIO_BASE_URL: "http://127.0.0.1:5678/v1" });
     expect(out.lmstudio.baseUrl).toBe("http://127.0.0.1:5678/v1");
   });
+  it("ORCAROUTER_BASE_URL overrides orcarouter baseUrl", () => {
+    const providers = { orcarouter: sampleProvider("https://api.orcarouter.ai/v1", "orcarouter/auto") };
+    const out = applyEnvOverrides(providers, { ORCAROUTER_BASE_URL: "https://gateway.example.com/v1" });
+    expect(out.orcarouter.baseUrl).toBe("https://gateway.example.com/v1");
+  });
   it("does not alter providers without a known env knob", () => {
     const providers = { custom: sampleProvider("http://file/v1", "m") };
     const out = applyEnvOverrides(providers, { LLAMACPP_BASE_URL: "http://env/v1" });
@@ -196,9 +201,24 @@ describe("shipped models.json", () => {
     expect(lmstudio.models.find((m) => m.id === "local-model")).toBeDefined();
   });
 
+  it("registers the orcarouter gateway on https://api.orcarouter.ai/v1", () => {
+    const result = loadProviders(pkgRoot, {});
+    const orcarouter = result.providers.orcarouter;
+    expect(orcarouter, "orcarouter provider should be present in shipped models.json").toBeDefined();
+    expect(orcarouter.baseUrl).toBe("https://api.orcarouter.ai/v1");
+    expect(orcarouter.api).toBe("openai-completions");
+    expect(orcarouter.apiKey).toBe("ORCAROUTER_API_KEY");
+    expect(orcarouter.models.find((m) => m.id === "orcarouter/auto")).toBeDefined();
+  });
+
   it("still registers llamacpp and ollama alongside lmstudio", () => {
     const result = loadProviders(pkgRoot, {});
-    expect(Object.keys(result.providers).sort()).toEqual(["llamacpp", "lmstudio", "ollama"]);
+    expect(Object.keys(result.providers).sort()).toEqual([
+      "llamacpp",
+      "lmstudio",
+      "ollama",
+      "orcarouter",
+    ]);
   });
 });
 

--- a/.pi/extensions/llama-cpp-provider/config.ts
+++ b/.pi/extensions/llama-cpp-provider/config.ts
@@ -51,6 +51,7 @@ const LEGACY_BASE_URL_ENV: Record<string, string> = {
   llamacpp: "LLAMACPP_BASE_URL",
   ollama: "OLLAMA_BASE_URL",
   lmstudio: "LMSTUDIO_BASE_URL",
+  orcarouter: "ORCAROUTER_BASE_URL",
 };
 
 /** Resolution order for the user-override file. First existing path wins. */

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to little-coder are documented here. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and little-coder's public interface (CLI, providers, tools, skills) follows semver starting at `v0.0.1` post-rename.
 
+## [Unreleased]
+
+### Added
+- **OrcaRouter cloud gateway as a named provider.** The shipped `models.json` now pre-registers an `orcarouter` provider (`https://api.orcarouter.ai/v1`, `ORCAROUTER_API_KEY`) with the gateway's auto-routing/fast/free aliases plus a few vendor-qualified frontier models, and `ORCAROUTER_BASE_URL` overrides the endpoint. Pick it with `little-coder --model orcarouter/orcarouter/auto`.
+
+---
+
 ## [v1.17.0] — 2026-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,9 +109,22 @@ export OLLAMA_API_KEY=noop
 export LMSTUDIO_API_KEY=noop
 ```
 
-`LLAMACPP_BASE_URL`, `OLLAMA_BASE_URL`, and `LMSTUDIO_BASE_URL` override the defaults (`http://127.0.0.1:8888/v1`, `http://127.0.0.1:11434/v1`, `http://127.0.0.1:1234/v1`).
+`LLAMACPP_BASE_URL`, `OLLAMA_BASE_URL`, and `LMSTUDIO_BASE_URL` override the defaults (`http://127.0.0.1:8888/v1`, `http://127.0.0.1:11434/v1`, `http://127.0.0.1:1234/v1`). `ORCAROUTER_BASE_URL` overrides the default `https://api.orcarouter.ai/v1` for the cloud gateway.
 
 For cloud providers, set the standard env (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) and pi will discover it.
+
+### OrcaRouter (cloud gateway)
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that fronts both open-weight and frontier models (DeepSeek, Qwen, Gemini, …) behind a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+The `orcarouter` provider ships pre-registered in `models.json` (base URL `https://api.orcarouter.ai/v1`). Set the key and pick a model:
+
+```bash
+export ORCAROUTER_API_KEY=sk-orca-...
+little-coder --model orcarouter/orcarouter/auto
+```
+
+The shipped entries cover the gateway's auto-routing alias (`orcarouter/auto`), the fast/cheap `orcarouter/fusion`, the free tier (`orcarouter/free`), and a few vendor-qualified frontier models. Any model your gateway exposes can be added the same way — [see Configuring models](#configuring-models). `ORCAROUTER_BASE_URL` overrides the endpoint if you self-host a gateway.
 
 ## Local model setup (optional)
 

--- a/models.json
+++ b/models.json
@@ -75,6 +75,67 @@
           "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
         }
       ]
+    },
+    "orcarouter": {
+      "api": "openai-completions",
+      "baseUrl": "https://api.orcarouter.ai/v1",
+      "apiKey": "ORCAROUTER_API_KEY",
+      "models": [
+        {
+          "id": "orcarouter/auto",
+          "name": "OrcaRouter (auto-routing gateway)",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 131072,
+          "maxTokens": 8192,
+          "cost": { "input": 1.5, "output": 6.0, "cacheRead": 1.0, "cacheWrite": 6.0 }
+        },
+        {
+          "id": "orcarouter/fusion",
+          "name": "OrcaRouter (fusion, fast/cheap)",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 131072,
+          "maxTokens": 8192,
+          "cost": { "input": 0.3, "output": 1.2, "cacheRead": 0.15, "cacheWrite": 1.2 }
+        },
+        {
+          "id": "orcarouter/free",
+          "name": "OrcaRouter (free tier)",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 65536,
+          "maxTokens": 4096,
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        },
+        {
+          "id": "deepseek/deepseek-v4-pro",
+          "name": "DeepSeek V4 Pro (via OrcaRouter)",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 131072,
+          "maxTokens": 8192,
+          "cost": { "input": 0.28, "output": 0.42, "cacheRead": 0.07, "cacheWrite": 0.42 }
+        },
+        {
+          "id": "qwen/qwen3.7-max",
+          "name": "Qwen3.7 Max (via OrcaRouter)",
+          "reasoning": true,
+          "input": ["text"],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": { "input": 0.5, "output": 2.0, "cacheRead": 0.25, "cacheWrite": 2.0 }
+        },
+        {
+          "id": "google/gemini-3.5-flash",
+          "name": "Gemini 3.5 Flash (via OrcaRouter)",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 262144,
+          "maxTokens": 8192,
+          "cost": { "input": 0.1, "output": 0.4, "cacheRead": 0.05, "cacheWrite": 0.4 }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds **OrcaRouter** as a named cloud-gateway provider in the shipped model registry, mirroring the existing data-driven provider flow.

- `models.json`: new `orcarouter` provider entry — `api: "openai-completions"`, `baseUrl: "https://api.orcarouter.ai/v1"`, `apiKey: "ORCAROUTER_API_KEY"` — with six models covering the gateway's auto-routing alias (`orcarouter/auto`), fast/cheap (`orcarouter/fusion`), free tier (`orcarouter/free`), and vendor-qualified frontier models (DeepSeek V4 Pro, Qwen3.7 Max, Gemini 3.5 Flash via OrcaRouter).
- `.pi/extensions/llama-cpp-provider/config.ts`: register `orcarouter` in the per-provider env-override map so `ORCAROUTER_BASE_URL` overrides the default endpoint.
- Tests: `ORCAROUTER_BASE_URL` override case + shipped-registry assertions (base URL, API-key env, `orcarouter/auto` presence).
- `README.md`: "OrcaRouter (cloud gateway)" section with setup, model list, and env vars.
- `CHANGELOG.md`: Unreleased entry.

[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible gateway that fronts both open-weight and frontier models behind a single endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## Verification

- `vitest run`: 614 passed; the 8 failures are pre-existing environment issues (launcher needs the bundled pi version on `--version`, browser-extract-retention hits live Wikipedia, glob hits a memory-bound walk) — confirmed identical on a clean `main` tree.
- `tsc --noEmit`: clean.
- Live test against `https://api.orcarouter.ai/v1` through the exact production path (`loadProviders` → `applyEnvOverrides` → `orcarouter` provider): `HTTP 200`, auto-routed to `deepseek-v4-pro`, reply `ORCA-OK`.

Disclosure: I'm an engineer on the OrcaRouter team.
