### PR TITLE
 llama-cpp-provider: detect live context window through llama-swap router mode

### DIFF
--- a/.pi/extensions/llama-cpp-provider/config.test.ts
+++ b/.pi/extensions/llama-cpp-provider/config.test.ts
@@ -10,8 +10,11 @@ import {
   mergeProviders,
   resolveOverridePath,
   propsUrlFor,
+  contextWindowFromModelList,
   contextWindowFromProps,
   probeContextWindow,
+  probeContextWindowViaModels,
+  resolveApiKey,
   withContextWindow,
   formatContextWindow,
   windowChange,
@@ -376,6 +379,95 @@ describe("probeContextWindow", () => {
     const got = await probeContextWindow("http://x:8888/v1", { fetchImpl, url: "http://other/props" });
     expect(seen).toBe("http://other/props");
     expect(got).toBe(40960);
+  });
+
+  it("sends the api key as a Bearer token (--api-key servers protect /props)", async () => {
+    let auth: string | undefined;
+    const fetchImpl = (async (_u: string, init?: RequestInit) => {
+      auth = (init?.headers as Record<string, string>)?.Authorization;
+      return okRes({ default_generation_settings: { n_ctx: 131072 } });
+    }) as unknown as typeof fetch;
+    const got = await probeContextWindow("http://x:8888/v1", { fetchImpl, apiKey: "sekrit" });
+    expect(auth).toBe("Bearer sekrit");
+    expect(got).toBe(131072);
+  });
+
+  it("sends no Authorization header when no key is available", async () => {
+    let headers: Record<string, string> | undefined;
+    const fetchImpl = (async (_u: string, init?: RequestInit) => {
+      headers = init?.headers as Record<string, string>;
+      return okRes({ n_ctx: 8192 });
+    }) as unknown as typeof fetch;
+    await probeContextWindow("http://x:8888/v1", { fetchImpl });
+    expect(headers?.Authorization).toBeUndefined();
+  });
+});
+
+describe("resolveApiKey", () => {
+  it("resolves an env-var name to its value", () => {
+    expect(resolveApiKey("LLAMACPP_API_KEY", { LLAMACPP_API_KEY: "sk-1" })).toBe("sk-1");
+  });
+  it("treats a value that names no env var as a literal key", () => {
+    expect(resolveApiKey("raw-key-123", {})).toBe("raw-key-123");
+  });
+  it("returns undefined when nothing is configured", () => {
+    expect(resolveApiKey(undefined, {})).toBeUndefined();
+    expect(resolveApiKey("", {})).toBeUndefined();
+  });
+});
+
+describe("contextWindowFromModelList (llama-swap router mode)", () => {
+  const loaded = {
+    id: "qwen-coder",
+    status: { value: "loaded", args: ["llama-server.exe", "--alias", "qwen-coder", "--ctx-size", "200000"] },
+    meta: { n_ctx: 200192, n_ctx_train: 262144 },
+  };
+  const unloaded = {
+    id: "ornith_coder",
+    status: { value: "unloaded", args: ["llama-server.exe", "--ctx-size", "200000", "--alias", "ornith_coder"] },
+  };
+  const router = { data: [unloaded, loaded], object: "list" };
+
+  it("prefers meta.n_ctx of the matching model when loaded", () => {
+    expect(contextWindowFromModelList(router, "qwen-coder")).toBe(200192);
+  });
+  it("falls back to --ctx-size in the launch args when unloaded", () => {
+    expect(contextWindowFromModelList(router, "ornith_coder")).toBe(200000);
+  });
+  it("ignores a router /props-shaped payload with no usable n_ctx", () => {
+    expect(contextWindowFromModelList({ default_generation_settings: { n_ctx: 0 } }, "qwen-coder")).toBeUndefined();
+  });
+  it("returns undefined when the model id is unknown among several", () => {
+    expect(contextWindowFromModelList(router, "nope")).toBeUndefined();
+  });
+});
+
+describe("probeContextWindowViaModels", () => {
+  const listRes = (body: unknown) => ({ ok: true, json: async () => body }) as Response;
+
+  it("hits <root>/v1/models with the Bearer key and reads meta.n_ctx", async () => {
+    let seenUrl = "";
+    let auth: string | undefined;
+    const fetchImpl = (async (u: string, init?: RequestInit) => {
+      seenUrl = u;
+      auth = (init?.headers as Record<string, string>)?.Authorization;
+      return listRes({ data: [{ id: "qwen-coder", meta: { n_ctx: 200192 } }] });
+    }) as unknown as typeof fetch;
+    const got = await probeContextWindowViaModels("http://127.0.0.1:9090/v1", {
+      fetchImpl,
+      apiKey: "sekrit",
+      modelId: "qwen-coder",
+    });
+    expect(seenUrl).toBe("http://127.0.0.1:9090/v1/models");
+    expect(auth).toBe("Bearer sekrit");
+    expect(got).toBe(200192);
+  });
+
+  it("returns undefined on a non-OK response or a throw", async () => {
+    const bad = (async () => ({ ok: false })) as unknown as typeof fetch;
+    expect(await probeContextWindowViaModels("http://x/v1", { fetchImpl: bad })).toBeUndefined();
+    const throwing = (async () => { throw new Error("ECONNREFUSED"); }) as unknown as typeof fetch;
+    expect(await probeContextWindowViaModels("http://x/v1", { fetchImpl: throwing })).toBeUndefined();
   });
 });
 

--- a/.pi/extensions/llama-cpp-provider/config.ts
+++ b/.pi/extensions/llama-cpp-provider/config.ts
@@ -295,6 +295,8 @@ export function contextWindowFromModelList(json: unknown, modelId?: string): num
 }
 
 /** Probe the router's /v1/models for the live context window of one model.
+ *  The key is sent even though llama.cpp leaves this endpoint open — a
+ *  self-hosted reverse proxy in front may still require it.
  *  Same best-effort contract as probeContextWindow: never throws. */
 export async function probeContextWindowViaModels(
   baseUrl: string,

--- a/.pi/extensions/llama-cpp-provider/config.ts
+++ b/.pi/extensions/llama-cpp-provider/config.ts
@@ -232,10 +232,23 @@ export function windowChange(
   return { from: registeredCtx, to: probed };
 }
 
+/** models.json stores apiKey as an ENV_VAR_NAME (see schema above); a value
+ *  that names no env var is treated as a literal key (llama-swap setups often
+ *  paste the raw key). Returns undefined when nothing usable is set. */
+export function resolveApiKey(configured: string | undefined, env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (!configured) return undefined;
+  return env[configured] ?? configured;
+}
+
 export interface ProbeDeps {
   fetchImpl?: typeof fetch;
   timeoutMs?: number;
   url?: string;
+  /** Sent as a Bearer token — /props sits behind the server's --api-key
+   *  middleware (llama.cpp and llama-swap), so an unauthenticated probe
+   *  gets 401 {"error":{"message":"Invalid API Key",...}} and the caller
+   *  silently falls back to the declared context window. */
+  apiKey?: string;
 }
 
 /** Ask a llama.cpp server for its live context window via /props. Returns
@@ -246,10 +259,12 @@ export async function probeContextWindow(baseUrl: string, deps: ProbeDeps = {}):
   const fetchImpl = deps.fetchImpl ?? fetch;
   const url = deps.url ?? propsUrlFor(baseUrl);
   const timeoutMs = deps.timeoutMs ?? 1500;
+  const headers: Record<string, string> = {};
+  if (deps.apiKey) headers.Authorization = `Bearer ${deps.apiKey}`;
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), timeoutMs);
   try {
-    const res = await fetchImpl(url, { signal: ctrl.signal });
+    const res = await fetchImpl(url, { signal: ctrl.signal, headers });
     if (!res.ok) return undefined;
     return contextWindowFromProps(await res.json());
   } catch {
@@ -257,4 +272,55 @@ export async function probeContextWindow(baseUrl: string, deps: ProbeDeps = {}):
   } finally {
     clearTimeout(timer);
   }
+}
+
+/** Router-mode fallback. llama-swap answers root /props itself ("role":"router",
+ *  default_generation_settings.n_ctx = 0), so the /props probe finds nothing.
+ *  Its /v1/models listing DOES carry per-model data: meta.n_ctx once the model
+ *  is loaded, otherwise --ctx-size in the recorded launch args. Returns
+ *  undefined when nothing usable is found. */
+export function contextWindowFromModelList(json: unknown, modelId?: string): number | undefined {
+  const j = json as { data?: any[] } | null;
+  const models = Array.isArray(j?.data) ? j.data : [];
+  const pick =
+    (modelId ? models.find((m) => m && m.id === modelId) : undefined) ??
+    (models.length === 1 ? models[0] : undefined);
+  if (!pick) return undefined;
+  const metaN = Number(pick.meta?.n_ctx);
+  if (Number.isFinite(metaN) && metaN > 0) return metaN;
+  const args: string[] = Array.isArray(pick.status?.args) ? pick.status.args : [];
+  const i = args.indexOf("--ctx-size");
+  const fromArgs = i >= 0 ? Number(args[i + 1]) : NaN;
+  return Number.isFinite(fromArgs) && fromArgs > 0 ? fromArgs : undefined;
+}
+
+/** Probe the router's /v1/models for the live context window of one model.
+ *  Same best-effort contract as probeContextWindow: never throws. */
+export async function probeContextWindowViaModels(
+  baseUrl: string,
+  deps: ProbeDeps & { modelId?: string } = {},
+): Promise<number | undefined> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const root = baseUrl.replace(/\/+$/, "").replace(/\/v1$/, "");
+  const headers: Record<string, string> = {};
+  if (deps.apiKey) headers.Authorization = `Bearer ${deps.apiKey}`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), deps.timeoutMs ?? 1500);
+  try {
+    const res = await fetchImpl(`${root}/v1/models`, { signal: ctrl.signal, headers });
+    if (!res.ok) return undefined;
+    return contextWindowFromModelList(await res.json(), deps.modelId);
+  } catch {
+    return undefined;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Try /props first (direct llama.cpp), then /v1/models (router mode). */
+export async function probeContextWindowAuto(
+  baseUrl: string,
+  deps: ProbeDeps & { modelId?: string } = {},
+): Promise<number | undefined> {
+  return (await probeContextWindow(baseUrl, deps)) ?? (await probeContextWindowViaModels(baseUrl, deps));
 }

--- a/.pi/extensions/llama-cpp-provider/index.ts
+++ b/.pi/extensions/llama-cpp-provider/index.ts
@@ -4,7 +4,8 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
   formatContextWindow,
   loadProviders,
-  probeContextWindow,
+  probeContextWindowAuto,
+  resolveApiKey,
   windowChange,
   withContextWindow,
   type ProviderModelEntry,
@@ -42,9 +43,10 @@ export default async function (pi: ExtensionAPI) {
 
   // Opt-out for offline / CI / no-server launches that don't want a startup probe.
   const probeDisabled = process.env.LITTLE_CODER_NO_CTX_PROBE === "1";
-  const probeOpts = () => ({
+  const probeOpts = (apiKey?: string) => ({
     url: process.env.LITTLE_CODER_LLAMACPP_PROPS_URL || undefined,
     timeoutMs: Number(process.env.LITTLE_CODER_CTX_PROBE_TIMEOUT_MS) || undefined,
+    apiKey, // /props is behind --api-key auth; without it the probe 401s
   });
 
   // Captured so the model_select hook below can re-register llamacpp with a new
@@ -59,10 +61,14 @@ export default async function (pi: ExtensionAPI) {
     // Auto-detect the server's live context window so the model registers with
     // the real n_ctx (e.g. a `-c 131072` server) instead of models.json's
     // declared default — the TUI readout, read-guard, and context budget all
-    // follow the registered window. llama.cpp-only (the /props endpoint); any
-    // failure silently keeps the declared window, so this never breaks startup.
+    // follow the registered window. Direct llama.cpp answers /props; a
+    // llama-swap router answers /v1/models per-model instead. Any failure
+    // silently keeps the declared window, so this never breaks startup.
     if (!probeDisabled && name === "llamacpp" && entry.models.length > 0) {
-      const probed = await probeContextWindow(entry.baseUrl, probeOpts());
+      const probed = await probeContextWindowAuto(entry.baseUrl, {
+        ...probeOpts(resolveApiKey(entry.apiKey)),
+        modelId: entry.models[0]?.id, // router mode: match this id in /v1/models
+      });
       if (probed) {
         models = withContextWindow(entry.models, probed);
       }
@@ -103,7 +109,10 @@ export default async function (pi: ExtensionAPI) {
       const previous = (event as any).previousModel;
       if (!model || model.provider !== "llamacpp" || !previous) return;
 
-      const probed = await probeContextWindow(lc.baseUrl, probeOpts());
+      const probed = await probeContextWindowAuto(lc.baseUrl, {
+        ...probeOpts(resolveApiKey(lc.apiKey)),
+        modelId: model.id,
+      });
       const change = windowChange(lc.registeredCtx, probed);
       if (!change) return;
 


### PR DESCRIPTION
Behind a llama-swap router, the startup context probe always failed silently and little-coder fell back to the static models.json window: the router answers /props itself with no usable n_ctx, and rejects it outright when an API key is set.

Changes

- resolveApiKey(): accepts both env-var names (documented schema) and literal keys.
- Probes send Authorization: Bearer <key> when one is configured.
- Router-mode fallback probeContextWindowViaModels(): reads <root>/v1/models, matches by model id, and takes meta.n_ctx (loaded) or --ctx-size from launch args (unloaded). Chained after /props, used at startup and by the issue #54 swap-time re-probe.

Compatibility

Direct llama.cpp without a key behaves exactly as before; a successful /props short-circuits before the fallback runs. All pre-existing tests pass unmodified.

Testing

tsc --noEmit clean, 60/60 provider tests pass (10 new), manually verified against llama-swap with --api-key.