### PR TITLE
fix(bg-shell): prevent stale context crash after session replacement

### DIFF
--- a/.pi/extensions/bg-shell/index.ts
+++ b/.pi/extensions/bg-shell/index.ts
@@ -81,9 +81,12 @@ function runningJobs(): Job[] {
 function setIndicator(ctx?: any): void {
   const target = ctx ?? uiCtx;
   if (ctx) uiCtx = ctx;
-  if (!target?.hasUI) return;
-  const live = runningJobs();
   try {
+    // hasUI throws on a stale ctx (after /new, fork, switch, reload). It must
+    // be read *inside* the try: reading it outside turned a child-process
+    // close event into an uncaughtException that killed the whole agent.
+    if (!target?.hasUI) return;
+    const live = runningJobs();
     if (live.length === 0) {
       target.ui.setWidget(INDICATOR_KEY, undefined, { placement: "belowEditor" });
       return;
@@ -185,9 +188,14 @@ function attachStreams(pi: ExtensionAPI, job: Job): void {
 
   const finish = (code: number | null) => {
     if (job.exited) return;
+    // Record the real exit before checking jobs: killJob's delayed SIGKILL
+    // reads this flag even after reapAll has removed the job from the map.
     job.exited = true;
     job.exitCode = code;
     job.endedAt = Date.now();
+    // Process events can outlive reapAll because SIGTERM is asynchronous.
+    // Do not let an old job repaint or wake a replacement session.
+    if (!jobs.has(job.id)) return;
     if (job.pending) {
       handleLine(pi, job, job.pending);
       job.pending = "";
@@ -267,6 +275,8 @@ export function reapAll(): void {
     if (!job.exited) killJob(job);
   }
   jobs.clear();
+  // Any captured ctx dies with the session; the next session_start re-captures.
+  uiCtx = null;
   if (stallTimer) {
     clearInterval(stallTimer);
     stallTimer = null;

--- a/.pi/extensions/bg-shell/index.ts
+++ b/.pi/extensions/bg-shell/index.ts
@@ -170,7 +170,7 @@ function handleLine(pi: ExtensionAPI, job: Job, line: string): void {
   if (job.pendingWake) clearTimeout(job.pendingWake);
   job.pendingWake = setTimeout(() => {
     job.pendingWake = undefined;
-    if (job.exited) return; // exit wake already covered it
+    if (job.exited || !jobs.has(job.id)) return;
     deliverWake(pi, job, event, Date.now());
   }, EXIT_COALESCE_MS);
   (job.pendingWake as any).unref?.();
@@ -178,6 +178,7 @@ function handleLine(pi: ExtensionAPI, job: Job, line: string): void {
 
 function attachStreams(pi: ExtensionAPI, job: Job): void {
   const onChunk = (buf: Buffer) => {
+    if (job.exited || !jobs.has(job.id)) return;
     const text = job.pending + buf.toString();
     const parts = text.split("\n");
     job.pending = parts.pop() ?? "";

--- a/.pi/extensions/bg-shell/integration.test.ts
+++ b/.pi/extensions/bg-shell/integration.test.ts
@@ -236,6 +236,21 @@ describe("session replacement cleanup", () => {
     expect(replacementSetWidget).toHaveBeenCalledTimes(replacementCallsBeforeClose);
   }, T);
 
+  it("ignores output emitted after a job is reaped", async () => {
+    const { sent, handlers, call } = wire();
+    const id = textOf(await call("ShellStart", {
+      command: "trap 'echo Traceback-after-reap; exit 0' TERM; echo ready; while :; do sleep 1; done",
+      label: "late-output",
+      wake_on: { exit: false, match: ["Traceback-after-reap"] },
+    })).match(/as (job\d+)/)![1];
+    expect(await until(async () => textOf(await call("ShellLog", { id })).includes("ready"))).toBe(true);
+
+    await handlers.session_shutdown({});
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(sent).toEqual([]);
+  }, T);
+
   it("does not force-kill a reaped job after it has exited", async () => {
     const kill = vi.spyOn(process, "kill");
     try {

--- a/.pi/extensions/bg-shell/integration.test.ts
+++ b/.pi/extensions/bg-shell/integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { execFileSync } from "node:child_process";
 import setupBgShell, { reapAll } from "./index.ts";
 
@@ -12,7 +12,7 @@ interface Sent {
   delivery: any;
 }
 
-function wire() {
+function wire(ctx: any = { hasUI: false, ui: {} }) {
   const sent: Sent[] = [];
   const tools: Record<string, any> = {};
   const handlers: Record<string, any> = {};
@@ -22,7 +22,6 @@ function wire() {
     sendMessage: (msg: any, delivery: any) => { sent.push({ content: msg.content, delivery }); },
   };
   setupBgShell(pi);
-  const ctx = { hasUI: false, ui: {} };
   const call = (name: string, params: any) =>
     tools[name].execute("id", params, undefined, undefined, ctx);
   return { sent, tools, handlers, call };
@@ -196,6 +195,84 @@ describe("bg-shell against real processes", () => {
       expect(textOf(r)).toContain("no such job");
     }
   }, T);
+});
+
+describe("session replacement cleanup", () => {
+  const T = 20_000;
+
+  it("contains stale-context errors while checking hasUI", async () => {
+    const { handlers } = wire();
+    const safeCtx = { hasUI: false, ui: {} };
+    const staleCtx = {
+      get hasUI() {
+        throw new Error("This extension ctx is stale after session replacement or reload.");
+      },
+      ui: {},
+    };
+
+    try {
+      await expect(handlers.session_start({}, staleCtx)).resolves.toBeUndefined();
+    } finally {
+      await handlers.session_start({}, safeCtx);
+    }
+  });
+
+  it("does not update the replacement UI or send a wake when a reaped job closes", async () => {
+    const replacementSetWidget = vi.fn();
+    const { sent, handlers, call } = wire({ hasUI: true, ui: { setWidget: vi.fn() } });
+    const started = textOf(await call("ShellStart", {
+      command: "sleep 300",
+      label: "reaped",
+    }));
+    const pid = Number(started.match(/\(pid (\d+)\)/)![1]);
+
+    await handlers.session_shutdown({});
+    await handlers.session_start({}, { hasUI: true, ui: { setWidget: replacementSetWidget } });
+    const replacementCallsBeforeClose = replacementSetWidget.mock.calls.length;
+    expect(replacementCallsBeforeClose).toBe(1);
+    expect(await until(() => !pidAlive(pid), 8000)).toBe(true);
+    await new Promise((r) => setTimeout(r, 100));
+    expect(sent).toEqual([]);
+    expect(replacementSetWidget).toHaveBeenCalledTimes(replacementCallsBeforeClose);
+  }, T);
+
+  it("does not force-kill a reaped job after it has exited", async () => {
+    const kill = vi.spyOn(process, "kill");
+    try {
+      const { handlers, call } = wire();
+      const started = textOf(await call("ShellStart", {
+        command: "sleep 300",
+        label: "reaped",
+      }));
+      const pid = Number(started.match(/\(pid (\d+)\)/)![1]);
+
+      await handlers.session_shutdown({});
+      expect(await until(() => !pidAlive(pid), 8000)).toBe(true);
+      await new Promise((r) => setTimeout(r, 4200));
+
+      expect(kill).not.toHaveBeenCalledWith(-pid, "SIGKILL");
+    } finally {
+      kill.mockRestore();
+    }
+  }, T);
+
+  it("drops the cached UI context during session shutdown", async () => {
+    let hasUIReads = 0;
+    const ctx = {
+      get hasUI() {
+        hasUIReads += 1;
+        return false;
+      },
+      ui: {},
+    };
+    const { handlers } = wire(ctx);
+
+    await handlers.session_start({}, ctx);
+    const readsBeforeShutdown = hasUIReads;
+    await handlers.session_shutdown({});
+
+    expect(hasUIReads).toBe(readsBeforeShutdown);
+  });
 });
 
 describe("the parent watchdog", () => {


### PR DESCRIPTION
## Summary
- Ignore late process output and completion side effects from jobs removed during session reaping.
- Clear the cached UI context and contain stale `hasUI` access during session replacement.
- Preserve exit-state tracking so graceful termination does not trigger a delayed `SIGKILL`.
- Add real-process regression coverage for stale contexts, replacement-session UI and wake isolation, late output, and force-kill cancellation.

## Root cause
`reapAll()` sends `SIGTERM` asynchronously and clears the job map before child-process `data` and `close` events necessarily finish. Those late events could access the stale cached UI context or wake and repaint the replacement session.

## Testing
- `npm test` — 677 passed, 14 skipped
- `npm run typecheck`
- Confirmed the late-output regression test fails before the stream guard and passes after it.

Closes #119