### PR TITLE
feat(manual-mode): make edits and writes also wait for users permissions

### DIFF
--- a/.pi/extensions/permission-gate/index.ts
+++ b/.pi/extensions/permission-gate/index.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { SHELL_TOOLS, detectWriteTargets, splitCommandChain } from "../_shared/shell-write.ts";
+import { createEditConfirmer } from "./manual-edit-confirm.ts";
 
 // Port of tools.py::_SAFE_PREFIXES + agent.py::_check_permission. Shell
 // commands not matching the whitelist are blocked in "auto" mode. In
@@ -80,7 +81,10 @@ function getPermissionMode(): "auto" | "accept-all" | "manual" {
   return "auto";
 }
 
+const WRITE_TOOLS = new Set(["write", "edit"]);
+
 export default function (pi: ExtensionAPI) {
+  const editConfirmer = createEditConfirmer();
   pi.on("tool_call", async (event, ctx) => {
     const mode = getPermissionMode();
     if (mode === "accept-all") return;
@@ -88,8 +92,15 @@ export default function (pi: ExtensionAPI) {
     const toolName = (event as any).toolName;
     const input: any = (event as any).input ?? (event as any).args;
 
-    // Only gate shell-family tools; pi has its own confirmation flow for
-    // destructive edits via the TUI.
+    if (WRITE_TOOLS.has(toolName)) {
+      if (mode === "manual") {
+        if ((await editConfirmer.confirm(ctx, String(toolName), input)) === "deny") {
+          return { block: true, reason: "edit cancelled by user" };
+        }
+      }
+      return;
+    }
+
     if (SHELL_TOOLS.has(toolName)) {
       const cmd = input?.command;
       if (typeof cmd === "string") {

--- a/.pi/extensions/permission-gate/manual-edit-confirm.test.ts
+++ b/.pi/extensions/permission-gate/manual-edit-confirm.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { createEditConfirmer } from "./manual-edit-confirm.ts";
+
+describe("createEditConfirmer", () => {
+  it("denies when no select UI is available (headless)", async () => {
+    const c = createEditConfirmer();
+    expect(await c.confirm({ ui: {} }, "write", { path: "/x" })).toBe("deny");
+  });
+
+  it("resolves Apply", async () => {
+    const c = createEditConfirmer();
+    const decision = await c.confirm(
+      {
+        cwd: "/cwd",
+        ui: { select: async () => "Apply" },
+      },
+      "edit",
+      { path: "/x.ts", edits: [{ oldText: "a", newText: "b" }] },
+    );
+    expect(decision).toBe("apply");
+  });
+
+  it("auto-approves after Apply all without prompting again", async () => {
+    const c = createEditConfirmer();
+    const first = await c.confirm(
+      { cwd: "/cwd", ui: { select: async () => "Apply all (this session)" } },
+      "write",
+      { path: "/x.ts", content: "y" },
+    );
+    expect(first).toBe("apply-all");
+    let prompted = false;
+    const second = await c.confirm(
+      { cwd: "/cwd", ui: { select: async () => { prompted = true; return "Deny"; } } },
+      "write",
+      { path: "/x.ts", content: "y" },
+    );
+    expect(second).toBe("apply");
+    expect(prompted).toBe(false);
+  });
+
+  it("keeps two instances isolated", async () => {
+    const a = createEditConfirmer();
+    const b = createEditConfirmer();
+    await a.confirm({ cwd: "/cwd", ui: { select: async () => "Apply all (this session)" } }, "write", { path: "/x", content: "y" });
+    let bPrompted = false;
+    await a.confirm({ cwd: "/cwd", ui: { select: async () => { bPrompted = true; return "Deny"; } } }, "write", { path: "/x", content: "y" });
+    expect(bPrompted).toBe(false);
+    let b2Prompted = false;
+    const bDecision = await b.confirm({ cwd: "/cwd", ui: { select: async () => { b2Prompted = true; return "Deny"; } } }, "write", { path: "/x", content: "y" });
+    expect(b2Prompted).toBe(true);
+    expect(bDecision).toBe("deny");
+  });
+});

--- a/.pi/extensions/permission-gate/manual-edit-confirm.ts
+++ b/.pi/extensions/permission-gate/manual-edit-confirm.ts
@@ -1,0 +1,38 @@
+// Manual-mode confirmation for write/edit tools (apply/deny/apply-all).
+
+export type EditDecision = "apply" | "deny" | "apply-all";
+
+const EDIT_OPTIONS = ["Apply", "Deny", "Apply all (this session)"] as const;
+
+export interface EditConfirmer {
+  confirm(ctx: any, toolName: string, input: any): Promise<EditDecision>;
+}
+
+/** Create a fresh confirmer for one session. Headless (no select) denies by default. */
+export function createEditConfirmer(): EditConfirmer {
+  let allowAll = false;
+
+  return {
+    async confirm(ctx: any, toolName: string, input: any): Promise<EditDecision> {
+      if (allowAll) return "apply";
+      const select = ctx?.ui?.select;
+      if (typeof select !== "function") return "deny";
+      const target =
+        typeof input?.path === "string"
+          ? input.path
+          : typeof input?.file_path === "string"
+            ? input.file_path
+            : "(unknown path)";
+      const choice = await select(
+        `About to ${toolName} ${target}. Apply this change?`,
+        [...EDIT_OPTIONS],
+      );
+      if (choice === "Apply all (this session)") {
+        allowAll = true;
+        return "apply-all";
+      }
+      if (choice === "Apply") return "apply";
+      return "deny";
+    },
+  };
+}

--- a/.pi/extensions/permission-gate/permission.test.ts
+++ b/.pi/extensions/permission-gate/permission.test.ts
@@ -95,6 +95,13 @@ describe("permission-gate tool_call interceptor", () => {
     return handler;
   }
 
+  // Fresh handler that owns its own edit-confirmer instance. Used by the
+  // write/edit "apply-all" tests so the latch does not leak into the shell
+  // tests or across randomized ordering.
+  function freshEditHandler() {
+    return getHandler();
+  }
+
   async function withMode<T>(mode: string | undefined, fn: () => T | Promise<T>): Promise<T> {
     const prev = process.env.LITTLE_CODER_PERMISSION_MODE;
     if (mode === undefined) delete process.env.LITTLE_CODER_PERMISSION_MODE;
@@ -194,6 +201,149 @@ describe("permission-gate tool_call interceptor", () => {
       );
       expect(result?.block).toBe(true);
       expect(result.reason).toBe("command cancelled by user");
+    });
+  });
+
+  describe("manual mode prompts for write/edit tools (apply/deny/apply-all)", () => {
+    // One shared handler for the whole block so the "Apply all" latch (a
+    // per-instance flag inside createEditConfirmer) persists across the
+    // sequential tests — matching a single pi session. The handler is created
+    // once for this describe, not via the global getHandler(), so it cannot
+    // leak into other describes via caching or random test order.
+    const sharedHandler = freshEditHandler();
+    function handler() {
+      return sharedHandler;
+    }
+
+    it("prompts on a write of a new file and applies when user picks Apply", async () => {
+      await withMode("manual", async () => {
+        let prompted = false;
+        const result = await handler()(
+          { toolName: "write", input: { path: "/tmp/new.ts", content: "x" } },
+          {
+            ui: {
+              select: async () => {
+                prompted = true;
+                return "Apply";
+              },
+            },
+          },
+        );
+        expect(prompted).toBe(true);
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it("prompts on an edit and blocks when user picks Deny", async () => {
+      await withMode("manual", async () => {
+        let prompted = false;
+        const result = await handler()(
+          { toolName: "edit", input: { path: "/tmp/exists.ts", edits: [] } },
+          {
+            ui: {
+              select: async () => {
+                prompted = true;
+                return "Deny";
+              },
+            },
+          },
+        );
+        expect(prompted).toBe(true);
+        expect(result?.block).toBe(true);
+        expect(result.reason).toBe("edit cancelled by user");
+      });
+    });
+
+    it("does not throw when notify is absent (headless manual)", async () => {
+      await withMode("manual", async () => {
+        const result = await handler()(
+          { toolName: "write", input: { path: "/tmp/new.ts", content: "x" } },
+          { ui: {} },
+        );
+        expect(result?.block).toBe(true);
+      });
+    });
+
+    it("reads file_path when path is absent", async () => {
+      await withMode("manual", async () => {
+        let prompted = false;
+        const result = await handler()(
+          { toolName: "write", input: { file_path: "/tmp/legacy.ts", content: "x" } },
+          {
+            ui: {
+              select: async () => {
+                prompted = true;
+                return "Apply";
+              },
+            },
+          },
+        );
+        expect(prompted).toBe(true);
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it("blocks edits when no select UI is available (headless manual)", async () => {
+      await withMode("manual", async () => {
+        const result = await handler()(
+          { toolName: "write", input: { path: "/tmp/new.ts", content: "x" } },
+          { ui: {} },
+        );
+        expect(result?.block).toBe(true);
+        expect(result.reason).toBe("edit cancelled by user");
+      });
+    });
+
+    it("does not prompt for write/edit in auto mode (write-guard owns it)", async () => {
+      await withMode("auto", async () => {
+        let prompted = false;
+        const result = await handler()(
+          { toolName: "write", input: { path: "/tmp/new.ts", content: "x" } },
+          { ui: { select: async () => { prompted = true; return "Apply"; } } },
+        );
+        expect(prompted).toBe(false);
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it("does not prompt for write/edit in accept-all mode", async () => {
+      await withMode("accept-all", async () => {
+        let prompted = false;
+        const result = await handler()(
+          { toolName: "edit", input: { path: "/tmp/x.ts", edits: [] } },
+          { ui: { select: async () => { prompted = true; return "Deny"; } } },
+        );
+        expect(prompted).toBe(false);
+        expect(result).toBeUndefined();
+      });
+    });
+
+    it("Apply all skips the prompt for every later edit in the session", async () => {
+      await withMode("manual", async () => {
+        let prompts = 0;
+        const ctx = {
+          ui: {
+            select: async () => {
+              prompts++;
+              return "Apply all (this session)";
+            },
+          },
+        };
+        const first = await handler()(
+          { toolName: "write", input: { path: "/tmp/a.ts", content: "x" } },
+          ctx,
+        );
+        expect(first).toBeUndefined();
+        expect(prompts).toBe(1);
+
+        // A subsequent edit must NOT prompt again.
+        const second = await handler()(
+          { toolName: "edit", input: { path: "/tmp/b.ts", edits: [] } },
+          ctx,
+        );
+        expect(second).toBeUndefined();
+        expect(prompts).toBe(1);
+      });
     });
   });
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Two env vars control the gate:
 
 | Env var | Values | Effect |
 |---|---|---|
-| `LITTLE_CODER_PERMISSION_MODE` | `auto` *(default)* / `accept-all` / `manual` | `auto`: block any shell command not on the whitelist. `accept-all`: skip the gate entirely, every shell call passes (the benchmark runner sets this). `manual`: prompt for confirmation before every shell command — the command is shown and you choose to execute (`y`) or cancel (`n`). |
+| `LITTLE_CODER_PERMISSION_MODE` | `auto` *(default)* / `accept-all` / `manual` | `auto`: block any shell command not on the whitelist. `accept-all`: skip the gate entirely, every shell call passes (the benchmark runner sets this). `manual`: prompt before every shell command (execute `y` / cancel `n`) and before every `write`/`edit` — you choose **Apply**, **Deny**, or **Apply all (this session)** to stop re-prompting for the rest of the session. `write`-guard's safety checks (reserved names, whole-file rewrites of existing files) still run even when you Apply. |
 | `LITTLE_CODER_BASH_ALLOW` | comma-separated prefixes | Extra allow-prefixes merged with the built-in list. **Trailing whitespace is meaningful**: `"make "` allows `make test` but not `makefoo`; `"make"` allows both. |
 
 Examples:


### PR DESCRIPTION
Hello,

another PR for manual mode 👋 

Manual mode was only gating shell commands `edit`/`write` slipped through without confirmation. Fixed: they now prompt Apply/Deny like shell does (native diff still shows, we just wire the gate).

Added `Apply all (this session)` for convenience if you don't want to review every edit, one click opts out for the rest of the session. Headless still denies by default.

🙇 