### PR TITLE
benchmarks: fix scoring and reliability defects in the Polyglot harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,21 @@ jobs:
 
       # --ignore-scripts: don't download playwright browsers on every CI run.
       - run: npm ci --ignore-scripts
+
+  pytest:
+    name: benchmarks pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - run: pip install pytest
+
+      # The PiRpc terminal-reason tests drive a fake pi subprocess
+      # (benchmarks/fake_pi.py), so they need neither the pi CLI nor a model
+      # server. The older tests in test_rpc_client.py self-skip without
+      # node_modules/.bin/pi.
+      - run: python -m pytest benchmarks/ -q

--- a/benchmarks/aider_polyglot.py
+++ b/benchmarks/aider_polyglot.py
@@ -40,8 +40,30 @@ TRAJECTORY_FIELD_CHARS = 20_000
 #: Give up if this many exercises fail in a row -- a broken environment,
 #: not broken exercises.
 MAX_CONSECUTIVE_ERRORS = 3
-#: Per-attempt RPC budget, seconds.
-ATTEMPT_TIMEOUT_S = 900
+def _positive_int_env(name: str, default: int) -> int:
+    """Parse a positive-integer env var, failing with a readable message.
+
+    A bare ValueError traceback (ATTEMPT_TIMEOUT_S=30m) is unhelpful, and a
+    silently-accepted 0 is worse: _drain_events_until returns immediately with
+    no events, so every exercise would record fail_timeout with a 0-turn
+    trajectory.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        raise SystemExit(f"{name}: expected a positive integer (seconds), got {raw!r}")
+    if value <= 0:
+        raise SystemExit(f"{name}: must be > 0, got {value}")
+    return value
+
+
+#: Per-attempt RPC budget, seconds. 900 suits a fast hosted model; a local
+#: model with a large thinking budget needs more, or every hard exercise is
+#: clock-limited rather than capability-limited.
+ATTEMPT_TIMEOUT_S = _positive_int_env("ATTEMPT_TIMEOUT_S", 900)
 DEFAULT_MODEL = "llamacpp/qwen3.6-35b-a3b"
 
 # Allowed tools for Polyglot — the core filesystem + bash toolbox. Ports

--- a/benchmarks/aider_polyglot.py
+++ b/benchmarks/aider_polyglot.py
@@ -22,6 +22,7 @@ import os
 import re
 import shutil
 import subprocess
+import uuid
 import sys
 import tempfile
 import time
@@ -34,6 +35,11 @@ BENCHMARK_ROOT = Path.home() / "Documents" / "polyglot-benchmark"
 REPO_ROOT = Path(__file__).parent.parent
 RESULTS_FILE = Path(__file__).parent / "results_full_polyglot.json"
 LOG_ROOT = Path(__file__).parent / "full_polyglot_logs"
+#: Identifies one invocation, so records and artifacts can be traced back to the
+#: run that produced them. RESULTS_FILE and LOG_ROOT are both deterministic and
+#: shared across runs, which has already caused artifacts from different runs to
+#: be compared as if they came from one.
+RUN_ID = f"{datetime.datetime.now():%Y%m%dT%H%M%S}-{uuid.uuid4().hex[:6]}"
 #: Caps applied to persisted trajectories -- see _dump_trajectory.
 TRAJECTORY_TEXT_CHARS = 200_000
 TRAJECTORY_FIELD_CHARS = 20_000
@@ -151,6 +157,25 @@ def _save_results(data: dict):
 # ── Core loop ──────────────────────────────────────────────────────────────
 
 
+def _purge_log_dir(log_dir: Path):
+    """Remove artifacts from previous runs of this exercise.
+
+    LOG_ROOT/<lang>/<exercise> is deterministic and nothing cleaned it, so a
+    one-attempt rerun left the previous run's trajectory_2/workdir_2 sitting
+    next to a fresh trajectory_1. Those pairs look like one run and are not:
+    comparing them produced a confident, wrong conclusion during review.
+    """
+    for pattern in ("trajectory_*", "workdir_*", "final_output*"):
+        for path in log_dir.glob(pattern):
+            if path.is_dir():
+                shutil.rmtree(path, ignore_errors=True)
+            else:
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+
+
 def _clip(value, limit: int):
     """Bound a field before it is serialised into the trajectory."""
     if isinstance(value, str):
@@ -208,9 +233,22 @@ def _dump_trajectory(log_dir, attempt_name, result, work=None):
             # A full 225-exercise run copies go/rust/cpp/js/java trees too;
             # without this a snapshot pulls in target/, build/, node_modules/
             # and compiled binaries, twice per exercise.
-            shutil.copytree(work, snap, ignore=shutil.ignore_patterns(
+            ignore = shutil.ignore_patterns(
                 "__pycache__", ".pytest_cache", "target", "build", "node_modules",
-                ".gradle", "CMakeFiles", "*.o", "*.so", "*.class", "*.rlib"))
+                ".gradle", "CMakeFiles", "*.o", "*.so", "*.class", "*.rlib")
+            # A file can vanish mid-walk while the agent is still active. One
+            # retry beats losing the snapshot to the blanket except below,
+            # which would leave only a .ERROR file for the very case the
+            # snapshot exists to explain.
+            for attempt_i in range(2):
+                try:
+                    shutil.copytree(work, snap, ignore=ignore)
+                    break
+                except FileNotFoundError:
+                    shutil.rmtree(snap, ignore_errors=True)
+                    if attempt_i == 1:
+                        raise
+                    time.sleep(0.5)
     except Exception as exc:
         # Diagnostics must never fail the exercise they are diagnosing.
         try:
@@ -261,6 +299,7 @@ def _run_exercise(
 
     log_dir = LOG_ROOT / lang / ex_name
     log_dir.mkdir(parents=True, exist_ok=True)
+    _purge_log_dir(log_dir)
 
     with tempfile.TemporaryDirectory() as tmp:
         work = Path(tmp) / ex_name
@@ -281,7 +320,13 @@ def _run_exercise(
             ta = time.time()
             r1 = rpc.prompt_and_collect(prompt, timeout=ATTEMPT_TIMEOUT_S)
             a_elapsed = time.time() - ta
+            # Snapshot BEFORE the tests run and before any retry prompt is
+            # sent, so the artifact reflects what THIS attempt produced. Both
+            # dumps previously happened after the block, so trajectory_1 and
+            # trajectory_2 captured the same post-retry tree.
+            _dump_trajectory(log_dir, "1", r1, work)
             passed, out = desc["run_tests"](work, desc["timeout_s"])
+            (log_dir / "final_output_1.txt").write_text(out)
             attempt = "pass_1" if passed else None
             timed_out = (not passed) and _was_clock_capped(r1, a_elapsed)
 
@@ -294,17 +339,13 @@ def _run_exercise(
                 tb = time.time()
                 r2 = rpc.prompt_and_collect(retry_prompt, timeout=ATTEMPT_TIMEOUT_S)
                 b_elapsed = time.time() - tb
+                _dump_trajectory(log_dir, "2", r2, work)
                 passed, out = desc["run_tests"](work, desc["timeout_s"])
+                (log_dir / "final_output_2.txt").write_text(out)
                 if passed:
                     attempt = "pass_2"
                 else:
                     timed_out = _was_clock_capped(r2, b_elapsed)
-
-        # Dumped AFTER the PiRpc block: on the timeout path the agent is still
-        # executing inside it, and copytree races file writes it is making.
-        _dump_trajectory(log_dir, "1", r1, work)
-        if r2 is not None:
-            _dump_trajectory(log_dir, "2", r2, work)
 
         elapsed = time.time() - t0
         (log_dir / "final_output.txt").write_text(out)
@@ -312,6 +353,7 @@ def _run_exercise(
             print(f"[{lang}/{ex_name}] {'PASS' if passed else 'FAIL'} in {elapsed:.1f}s on {attempt or 'fail'}")
 
         return {
+            "run_id": RUN_ID,
             "status": attempt or ("fail_timeout" if timed_out else "fail"),
             "elapsed_s": round(elapsed, 2),
             "turn_count": (r1.turn_count + (r2.turn_count if not attempt == "pass_1" and retry else 0)) if attempt else r1.turn_count,
@@ -331,6 +373,7 @@ def main():
 
     results = _load_results() if args.resume else {"exercises": {}, "meta": {}}
     results["meta"].update({
+        "run_id": RUN_ID,
         "model": args.model,
         "started_at": datetime.datetime.now().isoformat(),
     })

--- a/benchmarks/aider_polyglot.py
+++ b/benchmarks/aider_polyglot.py
@@ -273,6 +273,56 @@ def _build_prompt(exercise_name: str, stub_paths, test_paths, syntax_hint: str) 
 
 
 
+#: Environment knobs that change how the agent behaves, and therefore what a
+#: pass/fail means. Recorded so a result set is self-describing.
+_ENV_KNOBS = (
+    "PI_REASONING_MAX_TOKENS", "LITTLE_CODER_BASH_ALLOW",
+    "LITTLE_CODER_PERMISSION_MODE", "LITTLE_CODER_INJECT_MODE",
+    "LITTLE_CODER_SUBCODER_CONCURRENCY", "LITTLE_CODER_COMPACT_AT_PERCENT",
+)
+
+
+def _scoring_params(model: str, language: str, retry: bool, desc: dict) -> dict:
+    """Everything that affects whether an exercise passes.
+
+    Absent from results until now, so `--resume` could silently blend runs made
+    under different budgets into one file that looked homogeneous.
+    ATTEMPT_TIMEOUT_S is a module constant read from the environment at import,
+    not an argparse field, so it is captured here rather than from `args`.
+    """
+    return {
+        "model": model,
+        "language": language,
+        "attempt_timeout_s": ATTEMPT_TIMEOUT_S,
+        "test_timeout_s": desc.get("timeout_s"),
+        "retry": retry,
+        "score_in_copy": bool(desc.get("score_in_copy")),
+        "allowed_tools": sorted(set(ALLOWED_TOOLS)),
+        "env": {k: os.environ[k] for k in _ENV_KNOBS if k in os.environ},
+    }
+
+
+def _param_mismatches(recorded: dict, current: dict) -> list[str]:
+    """Which scoring parameters differ between a stored run and this one."""
+    if not recorded:
+        return ["<no parameters recorded>"]
+    out = []
+    for key in sorted(set(recorded) | set(current)):
+        was, now = recorded.get(key), current.get(key)
+        if was != now:
+            out.append(f"{key}: {was!r} -> {now!r}")
+    return out
+
+
+def _exit_code(records_written: dict) -> int:
+    """Non-zero when THIS invocation recorded a harness error.
+
+    Scoped to what this run wrote: a resumed run must not fail for an error it
+    inherited from an earlier file and never touched.
+    """
+    return 1 if any(str(r.get("status")) == "error" for r in records_written.values()) else 0
+
+
 def _stop_reason(result) -> str:
     """Why an attempt ended: agent_end | deadline | process_exit.
 
@@ -433,7 +483,10 @@ def _run_exercise(
             "stop_reason_1": _stop_reason(r1),
             "stop_reason_2": _stop_reason(r2) if r2 is not None else None,
             "elapsed_s": round(elapsed, 2),
-            "turn_count": (r1.turn_count + (r2.turn_count if not attempt == "pass_1" and retry else 0)) if attempt else r1.turn_count,
+            # Sum whatever actually ran. The previous expression dropped
+            # r2.turn_count whenever the exercise failed, so a two-attempt
+            # failure under-reported its own effort.
+            "turn_count": r1.turn_count + (r2.turn_count if r2 is not None else 0),
         }
 
 
@@ -449,15 +502,35 @@ def main():
     args = ap.parse_args()
 
     results = _load_results() if args.resume else {"exercises": {}, "meta": {}}
-    results["meta"].update({
-        "run_id": RUN_ID,
-        "model": args.model,
-        "started_at": datetime.datetime.now().isoformat(),
-    })
 
     desc = LANG_DESCRIPTORS.get(args.language)
     if desc is None:
         sys.exit(f"No descriptor for language '{args.language}'. Supported: {list(LANG_DESCRIPTORS)}")
+
+    params = _scoring_params(args.model, args.language, not args.no_retry, desc)
+    if args.resume:
+        mismatches = _param_mismatches(results["meta"].get("scoring_params", {}), params)
+        if mismatches and results["exercises"]:
+            # Warn rather than refuse: the documented canonical run deliberately
+            # changed a scoring parameter mid-run and resumed
+            # (docs/benchmark-qwen3.6-35b-a3b.md). Refusing would have blocked
+            # it. Every record carries its own parameters, so a mixed file stays
+            # analysable instead of merely looking homogeneous.
+            print("WARNING: resuming with different scoring parameters --", file=sys.stderr)
+            for line in mismatches:
+                print(f"  {line}", file=sys.stderr)
+            print("  Existing results were produced under the old values; new ones "
+                  "will carry the new values.", file=sys.stderr)
+
+    # runs[] keeps every invocation's parameters instead of overwriting them,
+    # so meta.model no longer describes only the last run of a mixed file.
+    results["meta"].setdefault("runs", []).append({
+        "run_id": RUN_ID,
+        "started_at": datetime.datetime.now().isoformat(),
+        "scoring_params": params,
+    })
+    results["meta"]["scoring_params"] = params
+    results["meta"]["run_id"] = RUN_ID
 
     practice = desc["practice_dir"]
     if args.exercise:
@@ -468,6 +541,7 @@ def main():
             names = names[:args.exercises]
 
     consecutive_errors = 0
+    written_this_run: dict[str, dict] = {}
     for name in names:
         key = f"{args.language}/{name}"
         if args.resume and results["exercises"].get(key, {}).get("status") in ("pass_1", "pass_2"):
@@ -488,7 +562,9 @@ def main():
             r = {"status": "error", "reason": f"{type(exc).__name__}: {exc}"[:400]}
             print(f"[{args.language}/{name}] ERROR {r['reason']}")
 
+        r["scoring_params"] = params
         results["exercises"][key] = r
+        written_this_run[key] = r
         _save_results(results)
         # Counts BOTH raised exceptions and returned {"status": "error"} --
         # _run_exercise returns that for a missing exercise directory, so a
@@ -508,6 +584,12 @@ def main():
         for k, v in results["exercises"].items()
     }, indent=2))
 
+    code = _exit_code(written_this_run)
+    if code:
+        bad = [k for k, v in written_this_run.items() if str(v.get("status")) == "error"]
+        print(f"harness errors in this run: {', '.join(bad)}", file=sys.stderr)
+    return code
+
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/benchmarks/aider_polyglot.py
+++ b/benchmarks/aider_polyglot.py
@@ -120,6 +120,7 @@ def _run_python(work: Path, timeout: int):
 
 LANG_DESCRIPTORS = {
     "python": {
+        "score_in_copy": True,
         "practice_dir": BENCHMARK_ROOT / "python" / "exercises" / "practice",
         "prepare": _prepare_python,
         "run_tests": _run_python,
@@ -257,17 +258,6 @@ def _dump_trajectory(log_dir, attempt_name, result, work=None):
             pass
 
 
-def _was_clock_capped(result, elapsed: float) -> bool:
-    """True when an attempt was cut off by the budget rather than finishing.
-
-    ``agent_ended`` is also False when pi crashes or closes stdout early, which
-    returns in seconds. That is a harness failure, not a slow model, and must
-    not be recorded as ``fail_timeout`` (which would additionally suppress the
-    retry). Require the attempt to have actually consumed the budget.
-    """
-    return (not result.agent_ended) and elapsed >= 0.9 * ATTEMPT_TIMEOUT_S
-
-
 def _build_prompt(exercise_name: str, stub_paths, test_paths, syntax_hint: str) -> str:
     stubs_list = "\n".join(f"  - {p}" for p in stub_paths)
     tests_list = "\n".join(f"  - {p}" for p in test_paths)
@@ -280,6 +270,88 @@ def _build_prompt(exercise_name: str, stub_paths, test_paths, syntax_hint: str) 
         "then implement the solution. When you believe the code is correct, "
         "stop calling tools."
     )
+
+
+
+def _stop_reason(result) -> str:
+    """Why an attempt ended: agent_end | deadline | process_exit.
+
+    Shim, deliberately: if rpc_client predates PromptResult.stop_reason (or that
+    change is reverted -- it has been once already), fall back to the old signal
+    so scoring degrades instead of breaking.
+    """
+    reason = getattr(result, "stop_reason", None)
+    if reason:
+        return reason
+    return "agent_end" if getattr(result, "agent_ended", False) else "deadline"
+
+
+def _is_empty_response(result) -> bool:
+    """pi finished the turn without doing anything.
+
+    An empty completion from the provider: agent_end arrives, but no tool call,
+    no turn of work and no assistant text. Six of sixteen recorded attempts in
+    this repo's log tree look like this. Classified as agent_end they read as
+    clean failures, hiding a provider-side fault behind a model-quality number.
+    """
+    return (
+        getattr(result, "agent_ended", False)
+        and (getattr(result, "turn_count", 0) or 0) <= 1
+        and not getattr(result, "tool_calls", None)
+        and not (getattr(result, "assistant_text", "") or "").strip()
+    )
+
+
+def _attempt_outcome(result) -> str:
+    """One attempt's outcome, independent of whether the tests passed."""
+    reason = _stop_reason(result)
+    if reason in ("process_exit", "deadline"):
+        return reason
+    if _is_empty_response(result):
+        return "empty_response"
+    return "completed"
+
+
+def _classify_status(passed: bool, attempt: str | None,
+                     outcome_1: str, outcome_2: str | None = None) -> str:
+    """Precedence for the recorded status. Pure, so it can be table-tested.
+
+    `passed` wins over everything: a pi that exits right after writing a correct
+    solution must not be downgraded from a pass to an error.
+    """
+    if passed:
+        return attempt or "pass_1"
+    last = outcome_2 if outcome_2 is not None else outcome_1
+    if outcome_2 is None:
+        # Only one attempt ran, so a dead process means the run itself failed.
+        if outcome_1 == "process_exit":
+            return "error"
+    elif outcome_2 == "process_exit":
+        # Attempt 1 was scored, so this is a failed exercise, not a broken run.
+        return "fail"
+    if last == "deadline":
+        return "fail_timeout"
+    if last == "empty_response":
+        return "empty_response"
+    return "fail"
+
+
+def _score(desc, work: Path, timeout: int):
+    """Run the tests against a COPY, so a live agent cannot influence the score.
+
+    prompt_and_collect returning does not mean pi is finished: measured on three
+    real exercises, pi still had a live child process at the moment the tests
+    would start. Scoring a copy removes the race on every path, keeps the retry's
+    session alive, and stops the test runner's droppings landing in the agent's
+    tree. Not enabled for cpp/rust, whose build dirs are absolute-path-bound and
+    would force a full rebuild per scoring pass.
+    """
+    if not desc.get("score_in_copy"):
+        return desc["run_tests"](work, timeout)
+    with tempfile.TemporaryDirectory() as scratch:
+        target = Path(scratch) / work.name
+        shutil.copytree(work, target)
+        return desc["run_tests"](target, timeout)
 
 
 def _run_exercise(
@@ -317,35 +389,38 @@ def _run_exercise(
             # indistinguishable from a completed one. Classified the same way
             # regardless of --no-retry, and re-evaluated for whichever attempt
             # ran last so a capped RETRY is not mislabelled a plain failure.
-            ta = time.time()
             r1 = rpc.prompt_and_collect(prompt, timeout=ATTEMPT_TIMEOUT_S)
-            a_elapsed = time.time() - ta
+            outcome_1 = _attempt_outcome(r1)
+            outcome_2 = None
+            # Belt-and-braces: an attempt that did not end cleanly may still
+            # have work in flight. Stop it before anything reads the tree.
+            # close() is idempotent, and this path never retries anyway.
+            if outcome_1 in ("deadline", "process_exit"):
+                rpc.close()
             # Snapshot BEFORE the tests run and before any retry prompt is
             # sent, so the artifact reflects what THIS attempt produced. Both
             # dumps previously happened after the block, so trajectory_1 and
             # trajectory_2 captured the same post-retry tree.
             _dump_trajectory(log_dir, "1", r1, work)
-            passed, out = desc["run_tests"](work, desc["timeout_s"])
+            passed, out = _score(desc, work, desc["timeout_s"])
             (log_dir / "final_output_1.txt").write_text(out)
             attempt = "pass_1" if passed else None
-            timed_out = (not passed) and _was_clock_capped(r1, a_elapsed)
 
-            if not passed and retry and not timed_out:
+            if not passed and retry and outcome_1 == "completed":
                 retry_prompt = (
                     "The tests failed. Output:\n\n```\n"
                     + out[-4000:]
                     + "\n```\n\nFix the implementation and try again."
                 )
-                tb = time.time()
                 r2 = rpc.prompt_and_collect(retry_prompt, timeout=ATTEMPT_TIMEOUT_S)
-                b_elapsed = time.time() - tb
+                outcome_2 = _attempt_outcome(r2)
+                if outcome_2 in ("deadline", "process_exit"):
+                    rpc.close()
                 _dump_trajectory(log_dir, "2", r2, work)
-                passed, out = desc["run_tests"](work, desc["timeout_s"])
+                passed, out = _score(desc, work, desc["timeout_s"])
                 (log_dir / "final_output_2.txt").write_text(out)
                 if passed:
                     attempt = "pass_2"
-                else:
-                    timed_out = _was_clock_capped(r2, b_elapsed)
 
         elapsed = time.time() - t0
         (log_dir / "final_output.txt").write_text(out)
@@ -354,7 +429,9 @@ def _run_exercise(
 
         return {
             "run_id": RUN_ID,
-            "status": attempt or ("fail_timeout" if timed_out else "fail"),
+            "status": _classify_status(passed, attempt, outcome_1, outcome_2),
+            "stop_reason_1": _stop_reason(r1),
+            "stop_reason_2": _stop_reason(r2) if r2 is not None else None,
             "elapsed_s": round(elapsed, 2),
             "turn_count": (r1.turn_count + (r2.turn_count if not attempt == "pass_1" and retry else 0)) if attempt else r1.turn_count,
         }

--- a/benchmarks/aider_polyglot.py
+++ b/benchmarks/aider_polyglot.py
@@ -34,6 +34,9 @@ BENCHMARK_ROOT = Path.home() / "Documents" / "polyglot-benchmark"
 REPO_ROOT = Path(__file__).parent.parent
 RESULTS_FILE = Path(__file__).parent / "results_full_polyglot.json"
 LOG_ROOT = Path(__file__).parent / "full_polyglot_logs"
+#: Caps applied to persisted trajectories -- see _dump_trajectory.
+TRAJECTORY_TEXT_CHARS = 200_000
+TRAJECTORY_FIELD_CHARS = 20_000
 #: Give up if this many exercises fail in a row -- a broken environment,
 #: not broken exercises.
 MAX_CONSECUTIVE_ERRORS = 3
@@ -125,6 +128,75 @@ def _save_results(data: dict):
 
 # ── Core loop ──────────────────────────────────────────────────────────────
 
+
+def _clip(value, limit: int):
+    """Bound a field before it is serialised into the trajectory."""
+    if isinstance(value, str):
+        return value[:limit]
+    if value is None:
+        return value
+    text = json.dumps(value, default=str)
+    return value if len(text) <= limit else text[:limit]
+
+
+def _dump_trajectory(log_dir, attempt_name, result, work=None):
+    """Persist what the harness otherwise discards.
+
+    Only the final pytest output survives a run today, so a failure can be seen
+    but not explained. PromptResult already carries the assistant text and every
+    tool call; the work dir is a TemporaryDirectory destroyed on scope exit,
+    taking the model's actual code with it.
+
+    Writes per attempt: trajectory_<n>.json, trajectory_<n>.txt, workdir_<n>/.
+    """
+    try:
+        payload = {
+            "attempt": attempt_name,
+            "agent_ended": getattr(result, "agent_ended", None),
+            "turn_count": getattr(result, "turn_count", None),
+            "compaction_events": getattr(result, "compaction_events", None),
+            "assistant_text": (getattr(result, "assistant_text", "") or "")[:TRAJECTORY_TEXT_CHARS],
+            # write/Write args carry whole file bodies and bash results whole
+            # command output; uncapped this reaches hundreds of MB per exercise.
+            "tool_calls": [
+                {
+                    **tc,
+                    "args": _clip(tc.get("args"), TRAJECTORY_FIELD_CHARS),
+                    "result_text": _clip(tc.get("result_text"), TRAJECTORY_FIELD_CHARS),
+                }
+                for tc in getattr(result, "tool_calls", [])
+            ],
+        }
+        (log_dir / f"trajectory_{attempt_name}.json").write_text(
+            json.dumps(payload, indent=2, default=str),
+            encoding="utf-8", errors="replace")
+        lines = []
+        for i, tc in enumerate(payload["tool_calls"], 1):
+            lines.append(f"--- [{i}] {tc.get('name')} err={tc.get('is_error')} ---")
+            lines.append(f"    args: {json.dumps(tc.get('args', {}), default=str)[:1500]}")
+            lines.append(f"    result: {str(tc.get('result_text', ''))[:1500]}")
+        lines.append("=== assistant text ===")
+        lines.append(payload["assistant_text"][:20000])
+        (log_dir / f"trajectory_{attempt_name}.txt").write_text(
+            "\n".join(lines), encoding="utf-8", errors="replace")
+        if work is not None and Path(work).exists():
+            snap = log_dir / f"workdir_{attempt_name}"
+            if snap.exists():
+                shutil.rmtree(snap, ignore_errors=True)
+            # A full 225-exercise run copies go/rust/cpp/js/java trees too;
+            # without this a snapshot pulls in target/, build/, node_modules/
+            # and compiled binaries, twice per exercise.
+            shutil.copytree(work, snap, ignore=shutil.ignore_patterns(
+                "__pycache__", ".pytest_cache", "target", "build", "node_modules",
+                ".gradle", "CMakeFiles", "*.o", "*.so", "*.class", "*.rlib"))
+    except Exception as exc:
+        # Diagnostics must never fail the exercise they are diagnosing.
+        try:
+            (log_dir / f"trajectory_{attempt_name}.ERROR").write_text(repr(exc))
+        except Exception:
+            pass
+
+
 def _was_clock_capped(result, elapsed: float) -> bool:
     """True when an attempt was cut off by the budget rather than finishing.
 
@@ -174,6 +246,7 @@ def _run_exercise(
         prompt = _build_prompt(ex_name, stubs, tests, desc["syntax_hint"])
 
         t0 = time.time()
+        r2 = None
         with PiRpc(model=model, cwd=str(work), allowed_tools=ALLOWED_TOOLS,
                    session_id=f"poly-{lang}-{ex_name}",
                    env={"LITTLE_CODER_PERMISSION_MODE": "accept-all"}) as rpc:
@@ -204,6 +277,12 @@ def _run_exercise(
                     attempt = "pass_2"
                 else:
                     timed_out = _was_clock_capped(r2, b_elapsed)
+
+        # Dumped AFTER the PiRpc block: on the timeout path the agent is still
+        # executing inside it, and copytree races file writes it is making.
+        _dump_trajectory(log_dir, "1", r1, work)
+        if r2 is not None:
+            _dump_trajectory(log_dir, "2", r2, work)
 
         elapsed = time.time() - t0
         (log_dir / "final_output.txt").write_text(out)

--- a/benchmarks/aider_polyglot.py
+++ b/benchmarks/aider_polyglot.py
@@ -34,6 +34,11 @@ BENCHMARK_ROOT = Path.home() / "Documents" / "polyglot-benchmark"
 REPO_ROOT = Path(__file__).parent.parent
 RESULTS_FILE = Path(__file__).parent / "results_full_polyglot.json"
 LOG_ROOT = Path(__file__).parent / "full_polyglot_logs"
+#: Give up if this many exercises fail in a row -- a broken environment,
+#: not broken exercises.
+MAX_CONSECUTIVE_ERRORS = 3
+#: Per-attempt RPC budget, seconds.
+ATTEMPT_TIMEOUT_S = 900
 DEFAULT_MODEL = "llamacpp/qwen3.6-35b-a3b"
 
 # Allowed tools for Polyglot — the core filesystem + bash toolbox. Ports
@@ -120,6 +125,17 @@ def _save_results(data: dict):
 
 # ── Core loop ──────────────────────────────────────────────────────────────
 
+def _was_clock_capped(result, elapsed: float) -> bool:
+    """True when an attempt was cut off by the budget rather than finishing.
+
+    ``agent_ended`` is also False when pi crashes or closes stdout early, which
+    returns in seconds. That is a harness failure, not a slow model, and must
+    not be recorded as ``fail_timeout`` (which would additionally suppress the
+    retry). Require the attempt to have actually consumed the budget.
+    """
+    return (not result.agent_ended) and elapsed >= 0.9 * ATTEMPT_TIMEOUT_S
+
+
 def _build_prompt(exercise_name: str, stub_paths, test_paths, syntax_hint: str) -> str:
     stubs_list = "\n".join(f"  - {p}" for p in stub_paths)
     tests_list = "\n".join(f"  - {p}" for p in test_paths)
@@ -161,20 +177,33 @@ def _run_exercise(
         with PiRpc(model=model, cwd=str(work), allowed_tools=ALLOWED_TOOLS,
                    session_id=f"poly-{lang}-{ex_name}",
                    env={"LITTLE_CODER_PERMISSION_MODE": "accept-all"}) as rpc:
-            r1 = rpc.prompt_and_collect(prompt, timeout=900)
+            # prompt_and_collect() returns partial events *silently* when
+            # agent_end never arrives (_drain_events_until returns `collected`,
+            # it does not raise), so a budget-capped attempt is otherwise
+            # indistinguishable from a completed one. Classified the same way
+            # regardless of --no-retry, and re-evaluated for whichever attempt
+            # ran last so a capped RETRY is not mislabelled a plain failure.
+            ta = time.time()
+            r1 = rpc.prompt_and_collect(prompt, timeout=ATTEMPT_TIMEOUT_S)
+            a_elapsed = time.time() - ta
             passed, out = desc["run_tests"](work, desc["timeout_s"])
             attempt = "pass_1" if passed else None
+            timed_out = (not passed) and _was_clock_capped(r1, a_elapsed)
 
-            if not passed and retry:
+            if not passed and retry and not timed_out:
                 retry_prompt = (
                     "The tests failed. Output:\n\n```\n"
                     + out[-4000:]
                     + "\n```\n\nFix the implementation and try again."
                 )
-                r2 = rpc.prompt_and_collect(retry_prompt, timeout=900)
+                tb = time.time()
+                r2 = rpc.prompt_and_collect(retry_prompt, timeout=ATTEMPT_TIMEOUT_S)
+                b_elapsed = time.time() - tb
                 passed, out = desc["run_tests"](work, desc["timeout_s"])
                 if passed:
                     attempt = "pass_2"
+                else:
+                    timed_out = _was_clock_capped(r2, b_elapsed)
 
         elapsed = time.time() - t0
         (log_dir / "final_output.txt").write_text(out)
@@ -182,7 +211,7 @@ def _run_exercise(
             print(f"[{lang}/{ex_name}] {'PASS' if passed else 'FAIL'} in {elapsed:.1f}s on {attempt or 'fail'}")
 
         return {
-            "status": attempt or "fail",
+            "status": attempt or ("fail_timeout" if timed_out else "fail"),
             "elapsed_s": round(elapsed, 2),
             "turn_count": (r1.turn_count + (r2.turn_count if not attempt == "pass_1" and retry else 0)) if attempt else r1.turn_count,
         }
@@ -217,17 +246,41 @@ def main():
         if args.exercises:
             names = names[:args.exercises]
 
+    consecutive_errors = 0
     for name in names:
         key = f"{args.language}/{name}"
         if args.resume and results["exercises"].get(key, {}).get("status") in ("pass_1", "pass_2"):
             continue
-        r = _run_exercise(
-            args.language, name, args.model,
-            verbose=args.verbose,
-            retry=not args.no_retry,
-        )
+        # Results are checkpointed atomically per exercise one line below, but
+        # an exception anywhere in _run_exercise still discarded every remaining
+        # exercise. Record and continue -- while still failing loudly if the
+        # environment itself is broken (missing pi CLI, model server down),
+        # which would otherwise write "error" 225 times and print a summary
+        # that reads like a finished 0% run.
+        try:
+            r = _run_exercise(
+                args.language, name, args.model,
+                verbose=args.verbose,
+                retry=not args.no_retry,
+            )
+        except Exception as exc:
+            r = {"status": "error", "reason": f"{type(exc).__name__}: {exc}"[:400]}
+            print(f"[{args.language}/{name}] ERROR {r['reason']}")
+
         results["exercises"][key] = r
         _save_results(results)
+        # Counts BOTH raised exceptions and returned {"status": "error"} --
+        # _run_exercise returns that for a missing exercise directory, so a
+        # stale benchmark checkout would otherwise never trip the guard.
+        if str(r.get("status")) == "error":
+            consecutive_errors += 1
+            if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
+                raise RuntimeError(
+                    f"aborting after {consecutive_errors} consecutive exercise "
+                    f"errors -- the environment looks broken, not the exercises"
+                )
+        else:
+            consecutive_errors = 0
 
     print(json.dumps({
         k: v["status"]

--- a/benchmarks/fake_pi.py
+++ b/benchmarks/fake_pi.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""A scriptable stand-in for the `pi` subprocess, for tests.
+
+The real tests spawn pi and skip when node_modules/.bin/pi is absent, so none of
+them exercise the JSONL event loop. EOF/deadline/crash behaviour cannot be
+expressed against a real agent anyway: it needs a process that exits on cue.
+
+Mode comes from FAKE_PI_MODE. Reads JSONL requests on stdin, emits JSONL on
+stdout, exactly as rpc_client expects.
+"""
+import json, os, sys, time
+
+
+def emit(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+
+def read_prompt():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("type") == "prompt":
+            return msg
+    return None
+
+
+def main():
+    mode = os.environ.get("FAKE_PI_MODE", "clean")
+
+    if mode == "exit_before_ack":
+        sys.stderr.write("fake_pi: dying before ack\n")
+        sys.stderr.flush()
+        os._exit(3)
+
+    msg = read_prompt()
+    if msg is None:
+        return
+    rid = msg.get("id")
+
+    if mode == "crash_after_ack":
+        emit({"type": "response", "id": rid, "success": True})
+        emit({"type": "agent_start"})
+        sys.stderr.write("fake_pi: boom\n")
+        sys.stderr.flush()
+        os._exit(1)
+
+    if mode == "hang_after_ack":
+        emit({"type": "response", "id": rid, "success": True})
+        emit({"type": "agent_start"})
+        time.sleep(3600)
+
+    if mode == "end_then_exit":
+        # agent_end and EOF in the same breath -- the ordering hazard
+        emit({"type": "response", "id": rid, "success": True})
+        emit({"type": "turn_end"})
+        emit({"type": "agent_end"})
+        os._exit(0)
+
+    if mode == "end_then_write":
+        emit({"type": "response", "id": rid, "success": True})
+        emit({"type": "turn_end"})
+        emit({"type": "agent_end"})
+        deadline = time.time() + 2
+        i = 0
+        while time.time() < deadline:
+            with open(os.path.join(os.getcwd(), "late_write.txt"), "a") as fh:
+                fh.write(f"{i}\n")
+            i += 1
+            time.sleep(0.2)
+        emit({"type": "agent_settled"})
+        time.sleep(30)
+        return
+
+    # default: clean single turn with one tool call
+    emit({"type": "response", "id": rid, "success": True})
+    emit({"type": "agent_start"})
+    emit({"type": "message_update",
+          "assistantMessageEvent": {"type": "text_delta", "delta": "hello"}})
+    emit({"type": "tool_execution_start", "toolCallId": "t1", "toolName": "read", "args": {"path": "x"}})
+    emit({"type": "tool_execution_end", "toolCallId": "t1", "toolName": "read",
+          "result": {"content": [{"type": "text", "text": "ok"}]}, "isError": False})
+    emit({"type": "turn_end"})
+    emit({"type": "agent_end"})
+    emit({"type": "agent_settled"})
+    time.sleep(30)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/gaia.py
+++ b/benchmarks/gaia.py
@@ -180,6 +180,7 @@ def _run_task(
         turn_count = 0
         compactions = 0
         agent_ended = False
+        stop_reason = ""
         stderr = ""
         agent_error = ""
 
@@ -198,6 +199,11 @@ def _run_task(
                 turn_count = result.turn_count
                 compactions = result.compaction_events
                 agent_ended = result.agent_ended
+                # Why the run ended. Without it a crashed pi scores whatever
+                # extract_final_answer() finds in a truncated transcript --
+                # persisted, in seconds, indistinguishable from a genuine
+                # wrong answer. getattr for older rpc_client.
+                stop_reason = getattr(result, "stop_reason", "")
                 notifications = rpc.notifications()
                 stderr = rpc.stderr()
         except Exception as e:
@@ -231,6 +237,7 @@ def _run_task(
             "n_notifications": len(notifications),
             "compactions": compactions,
             "agent_ended": agent_ended,
+            "stop_reason": stop_reason,
             "agent_error": agent_error,
             "model_answer": model_answer,
         }

--- a/benchmarks/harbor_adapter/little_coder_agent.py
+++ b/benchmarks/harbor_adapter/little_coder_agent.py
@@ -228,7 +228,11 @@ class LittleCoderAgent(BaseAgent):
             )
             try:
                 result = await asyncio.to_thread(rpc.prompt_and_collect, prompt, 3600)
+                stop_reason = getattr(result, "stop_reason", "unknown")
                 if log_fh:
+                    # Distinguishes a crashed pi from a model that ran long;
+                    # both used to look identical here.
+                    log_fh.write(f"=== stop_reason: {stop_reason} ===\n")
                     log_fh.write(f"=== assistant text ===\n{result.assistant_text}\n\n")
                     for tc in result.tool_calls:
                         log_fh.write(f">> {tc['name']}({tc.get('args', {})})\n")
@@ -245,6 +249,7 @@ class LittleCoderAgent(BaseAgent):
                 # Harbor's AgentContext: populate what we can. Token usage
                 # isn't currently plumbed through pi-ai; leave None.
                 context.metadata = {
+                    "stop_reason": stop_reason,
                     "n_tool_calls": len(result.tool_calls),
                     "n_turns": result.turn_count,
                     "n_compactions": result.compaction_events,

--- a/benchmarks/rpc_client.py
+++ b/benchmarks/rpc_client.py
@@ -49,6 +49,10 @@ def _extension_paths() -> list[str]:
     return paths
 
 
+class PiProcessExited(RuntimeError):
+    """pi exited before completing the request. Carries its stderr tail."""
+
+
 @dataclass
 class PromptResult:
     """Outcome of a single prompt_and_collect() call."""
@@ -57,6 +61,11 @@ class PromptResult:
     agent_ended: bool = False
     compaction_events: int = 0
     turn_count: int = 0
+    #: Why the call returned: "agent_end" (pi finished the turn), "deadline"
+    #: (budget expired), or "process_exit" (pi died mid-run). Callers must not
+    #: infer this from elapsed time -- a crash burns the full budget too,
+    #: because stdout EOF used not to wake the drain.
+    stop_reason: str = "agent_end"
 
 
 class PiRpc:
@@ -137,6 +146,8 @@ class PiRpc:
         self._lock = threading.Lock()
         self._cv = threading.Condition(self._lock)
         self._closed = False
+        #: Set once pi's stdout reaches EOF, i.e. the process is going away.
+        self._eof = False
         self._stderr_buf: list[str] = []
         # ctx.ui.notify messages from extensions — used by the benchmark
         # harnesses to count skill injections, thinking-budget fires,
@@ -153,6 +164,18 @@ class PiRpc:
         # Use explicit readline() — `for line in stdout` buffers opaquely
         # and can delay event delivery well past newlines in pi's stream.
         assert self._proc.stdout is not None
+        try:
+            self._read_loop_body()
+        finally:
+            # try/finally, not "after the break": if the loop raises (e.g. the
+            # pipe is torn down under it) waiters must still be woken, or they
+            # block for the full timeout and a crash is indistinguishable from
+            # a deadline.
+            with self._cv:
+                self._eof = True
+                self._cv.notify_all()
+
+    def _read_loop_body(self):
         while True:
             line = self._proc.stdout.readline()
             if not line:
@@ -237,11 +260,17 @@ class PiRpc:
         start = time.time()
         with self._cv:
             while rid not in self._responses:
+                if self._eof:
+                    break
                 remaining = timeout - (time.time() - start)
                 if remaining <= 0:
                     raise TimeoutError(f"pi did not respond to request {rid} within {timeout}s")
                 self._cv.wait(timeout=remaining)
-            return self._responses.pop(rid)
+            if rid in self._responses:
+                return self._responses.pop(rid)
+        raise PiProcessExited(
+            f"pi exited before acknowledging request {rid}; stderr:\n{self.stderr()}"
+        )
 
     def _drain_events_until(self, predicate, timeout: float) -> list[dict]:
         """Drain events until `predicate(event)` returns True or timeout."""
@@ -254,6 +283,8 @@ class PiRpc:
                     collected.append(ev)
                     if predicate(ev):
                         return collected
+                if self._eof:
+                    return collected      # queue drained above; pi is gone
                 remaining = timeout - (time.time() - start)
                 if remaining <= 0:
                     return collected
@@ -262,6 +293,8 @@ class PiRpc:
     # ── Public API ───────────────────────────────────────────────────────
     def prompt_and_collect(self, message: str, timeout: float = 900) -> PromptResult:
         """Send a prompt, drain events until agent_end, return summary."""
+        if self._closed:
+            raise RuntimeError("prompt_and_collect() on a closed PiRpc")
         rid = str(uuid.uuid4())
         self._send({"id": rid, "type": "prompt", "message": message})
         resp = self._await_response(rid, timeout=30)
@@ -274,6 +307,15 @@ class PiRpc:
         )
 
         result = PromptResult()
+        # Derived from what was observed, not from how long it took: a crash
+        # burns the same wall-clock as a deadline.
+        saw_agent_end = any(ev.get("type") == "agent_end" for ev in events)
+        if saw_agent_end:
+            result.stop_reason = "agent_end"
+        elif self._eof or self._proc.poll() is not None:
+            result.stop_reason = "process_exit"
+        else:
+            result.stop_reason = "deadline"
         pending: dict[str, dict] = {}
         for ev in events:
             t = ev.get("type")
@@ -309,7 +351,20 @@ class PiRpc:
         self._send({"id": rid, "type": "new_session"})
         self._await_response(rid)
 
+    def _settle_stderr(self, timeout: float = 1.0):
+        """Let the existing stderr reader finish once pi is gone.
+
+        Before the EOF fix, callers only reached stderr() after a full timeout,
+        by which point the reader had long since drained. Returning promptly
+        now races it, so wait briefly for the thread to finish.
+        """
+        if self._eof or self._proc.poll() is not None:
+            reader = getattr(self, "_stderr_reader", None)
+            if reader is not None and reader.is_alive():
+                reader.join(timeout=timeout)
+
     def stderr(self) -> str:
+        self._settle_stderr()
         return "\n".join(self._stderr_buf)
 
     def notifications(self) -> list[dict]:

--- a/benchmarks/tb_adapter/little_coder_agent.py
+++ b/benchmarks/tb_adapter/little_coder_agent.py
@@ -265,6 +265,10 @@ class LittleCoderAgent(BaseAgent):
                 text_out = result.assistant_text
                 turns = result.turn_count
                 if log_fh:
+                    # Distinguishes a crashed pi from a model that simply ran
+                    # long; both used to look identical in this log.
+                    log_fh.write(
+                        f"=== stop_reason: {getattr(result, 'stop_reason', 'unknown')} ===\n")
                     log_fh.write(f"=== assistant text ===\n{text_out}\n\n")
                     for tc in result.tool_calls:
                         log_fh.write(f">> {tc['name']}({tc.get('args', {})})\n")

--- a/benchmarks/test_polyglot_artifacts.py
+++ b/benchmarks/test_polyglot_artifacts.py
@@ -1,0 +1,137 @@
+"""Artifact hygiene: stale files must not survive a rerun, and each attempt's
+snapshot must reflect that attempt.
+
+Regression cover for a bug that produced a wrong review conclusion: LOG_ROOT is
+deterministic and was never purged, so a one-attempt rerun left the PREVIOUS
+run's trajectory_2/workdir_2 beside a fresh trajectory_1. Comparing that pair
+looks like comparing two attempts of one run. It is not.
+"""
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import aider_polyglot as AP  # noqa: E402
+
+
+def test_purge_removes_prior_run_artifacts(tmp_path):
+    log_dir = tmp_path / "python" / "some-exercise"
+    log_dir.mkdir(parents=True)
+    (log_dir / "trajectory_1.json").write_text("{}")
+    (log_dir / "trajectory_2.json").write_text("{}")
+    (log_dir / "final_output.txt").write_text("old")
+    (log_dir / "final_output_2.txt").write_text("old")
+    (log_dir / "workdir_1").mkdir()
+    (log_dir / "workdir_2").mkdir()
+    (log_dir / "workdir_2" / "stale.py").write_text("stale")
+    keep = log_dir / "notes.md"
+    keep.write_text("not ours")
+
+    AP._purge_log_dir(log_dir)
+
+    assert not list(log_dir.glob("trajectory_*"))
+    assert not list(log_dir.glob("workdir_*"))
+    assert not list(log_dir.glob("final_output*"))
+    assert keep.exists(), "purge must only remove harness-owned artifacts"
+
+
+def test_purge_is_safe_on_empty_dir(tmp_path):
+    d = tmp_path / "empty"
+    d.mkdir()
+    AP._purge_log_dir(d)  # must not raise
+
+
+def test_snapshots_of_two_attempts_differ(tmp_path):
+    """The B3 regression: each attempt's workdir must capture its own state."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    work = tmp_path / "work"
+    work.mkdir()
+
+    class R:
+        agent_ended = True
+        turn_count = 1
+        compaction_events = 0
+        assistant_text = "a"
+        tool_calls = []
+
+    (work / "solution.py").write_text("attempt one")
+    AP._dump_trajectory(log_dir, "1", R(), work)
+    (work / "solution.py").write_text("attempt two -- different")
+    AP._dump_trajectory(log_dir, "2", R(), work)
+
+    one = (log_dir / "workdir_1" / "solution.py").read_text()
+    two = (log_dir / "workdir_2" / "solution.py").read_text()
+    assert one == "attempt one"
+    assert two == "attempt two -- different"
+    assert one != two
+
+
+class _FakeRpc:
+    """Stands in for PiRpc: each prompt mutates the worktree, so the ordering
+    of snapshot vs prompt is observable."""
+
+    def __init__(self, *a, **kw):
+        self.cwd = Path(kw["cwd"])
+        self.n = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def prompt_and_collect(self, message, timeout=900):
+        self.n += 1
+        (self.cwd / "solution.py").write_text(f"written by attempt {self.n}")
+
+        class R:
+            agent_ended = True
+            turn_count = 1
+            compaction_events = 0
+            assistant_text = f"attempt {self.n}"
+            tool_calls = []
+        return R()
+
+
+def test_attempt1_snapshot_predates_the_retry_prompt(tmp_path, monkeypatch):
+    """The B3 regression, at the call site where it actually lived.
+
+    Both _dump_trajectory calls used to sit after the `with PiRpc(...)` block,
+    so attempt 1's snapshot captured the post-retry tree. Driving _run_exercise
+    with a fake agent that rewrites the file on every prompt makes the ordering
+    observable: if attempt 1 is snapshotted late, workdir_1 holds attempt 2's
+    text.
+    """
+    src = tmp_path / "practice" / "ex"
+    src.mkdir(parents=True)
+    (src / "ex.py").write_text("stub")
+    (src / "ex_test.py").write_text("test")
+
+    def prepare(s, w):
+        AP._copy_exercise(s, w)
+        return [w / "ex.py"], [w / "ex_test.py"]
+
+    monkeypatch.setitem(AP.LANG_DESCRIPTORS, "faker", {
+        "practice_dir": tmp_path / "practice",
+        "prepare": prepare,
+        "run_tests": lambda work, timeout: (False, "boom"),   # always fail -> retry
+        "syntax_hint": "",
+        "timeout_s": 5,
+    })
+    monkeypatch.setattr(AP, "PiRpc", _FakeRpc)
+    monkeypatch.setattr(AP, "LOG_ROOT", tmp_path / "logs")
+
+    AP._run_exercise("faker", "ex", "fake/model", verbose=False, retry=True)
+
+    log_dir = tmp_path / "logs" / "faker" / "ex"
+    one = (log_dir / "workdir_1" / "solution.py").read_text()
+    two = (log_dir / "workdir_2" / "solution.py").read_text()
+    assert one == "written by attempt 1", f"attempt 1 snapshot is stale: {one!r}"
+    assert two == "written by attempt 2"
+    assert (log_dir / "final_output_1.txt").exists()
+    assert (log_dir / "final_output_2.txt").exists()
+
+
+def test_run_id_is_stable_within_a_process():
+    assert AP.RUN_ID and AP.RUN_ID == AP.RUN_ID

--- a/benchmarks/test_polyglot_classify.py
+++ b/benchmarks/test_polyglot_classify.py
@@ -1,0 +1,126 @@
+"""Precedence rules for the recorded status, and score-in-a-copy isolation.
+
+Pure functions, table-tested: this is where a wrong precedence silently turns a
+pass into an error, or hides a provider fault as a model failure.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import aider_polyglot as AP  # noqa: E402
+
+
+class Res:
+    def __init__(self, stop_reason=None, agent_ended=True, turn_count=3,
+                 tool_calls=None, assistant_text="did work"):
+        if stop_reason is not None:
+            self.stop_reason = stop_reason
+        self.agent_ended = agent_ended
+        self.turn_count = turn_count
+        self.tool_calls = tool_calls if tool_calls is not None else [{"name": "read"}]
+        self.assistant_text = assistant_text
+
+
+# ── _stop_reason shim ────────────────────────────────────────────────────
+def test_stop_reason_prefers_the_real_field():
+    assert AP._stop_reason(Res(stop_reason="process_exit")) == "process_exit"
+
+
+def test_stop_reason_degrades_when_field_absent():
+    """rpc_client without stop_reason (or reverted) must not break scoring."""
+    assert AP._stop_reason(Res(agent_ended=True)) == "agent_end"
+    assert AP._stop_reason(Res(agent_ended=False)) == "deadline"
+
+
+# ── empty responses ──────────────────────────────────────────────────────
+@pytest.mark.parametrize("res,expected", [
+    (Res(stop_reason="agent_end", turn_count=1, tool_calls=[], assistant_text=""), True),
+    (Res(stop_reason="agent_end", turn_count=1, tool_calls=[], assistant_text="   "), True),
+    (Res(stop_reason="agent_end", turn_count=1, tool_calls=[{"name": "read"}], assistant_text=""), False),
+    (Res(stop_reason="agent_end", turn_count=4, tool_calls=[], assistant_text="text"), False),
+    (Res(stop_reason="deadline", agent_ended=False, turn_count=0, tool_calls=[], assistant_text=""), False),
+])
+def test_is_empty_response(res, expected):
+    assert AP._is_empty_response(res) is expected
+
+
+# ── _attempt_outcome wires the pieces together ───────────────────────────
+@pytest.mark.parametrize("res,expected", [
+    (Res(stop_reason="process_exit"), "process_exit"),
+    (Res(stop_reason="deadline"), "deadline"),
+    (Res(stop_reason="agent_end"), "completed"),
+    # the branch a mutation test caught as untested: an agent_end with no work
+    # must become empty_response, not completed
+    (Res(stop_reason="agent_end", turn_count=1, tool_calls=[], assistant_text=""),
+     "empty_response"),
+    # process_exit outranks emptiness -- the process dying is the bigger fact
+    (Res(stop_reason="process_exit", turn_count=1, tool_calls=[], assistant_text=""),
+     "process_exit"),
+])
+def test_attempt_outcome(res, expected):
+    assert AP._attempt_outcome(res) == expected
+
+
+# ── precedence table ─────────────────────────────────────────────────────
+@pytest.mark.parametrize("passed,attempt,o1,o2,expected", [
+    # passing beats everything, including a process that then died
+    (True,  "pass_1", "completed",      None,            "pass_1"),
+    (True,  "pass_1", "process_exit",   None,            "pass_1"),
+    (True,  "pass_2", "completed",      "process_exit",  "pass_2"),
+    # single attempt
+    (False, None,     "process_exit",   None,            "error"),
+    (False, None,     "deadline",       None,            "fail_timeout"),
+    (False, None,     "empty_response", None,            "empty_response"),
+    (False, None,     "completed",      None,            "fail"),
+    # retry ran: attempt 1 was scored, so a dead pi is a failed exercise
+    (False, None,     "completed",      "process_exit",  "fail"),
+    (False, None,     "completed",      "deadline",      "fail_timeout"),
+    (False, None,     "completed",      "empty_response","empty_response"),
+    (False, None,     "completed",      "completed",     "fail"),
+])
+def test_classify_status(passed, attempt, o1, o2, expected):
+    assert AP._classify_status(passed, attempt, o1, o2) == expected
+
+
+def test_a_pass_is_never_downgraded_to_error():
+    """Regression guard: applying process_exit before checking `passed` would
+    turn a pi that exited right after writing a correct solution into an error."""
+    assert AP._classify_status(True, "pass_1", "process_exit", None) == "pass_1"
+
+
+# ── score in a copy ──────────────────────────────────────────────────────
+def test_score_in_copy_does_not_run_in_the_agents_tree(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "solution.py").write_text("x = 1")
+    seen = {}
+
+    def run_tests(where, timeout):
+        seen["where"] = Path(where)
+        (Path(where) / "test_droppings").write_text("pytest was here")
+        return True, "ok"
+
+    desc = {"score_in_copy": True, "run_tests": run_tests, "timeout_s": 5}
+    passed, out = AP._score(desc, work, 5)
+
+    assert passed and out == "ok"
+    assert seen["where"] != work, "tests ran in the agent's own tree"
+    assert (work / "solution.py").exists()
+    assert not (work / "test_droppings").exists(), "scoring polluted the agent's tree"
+
+
+def test_score_without_flag_uses_the_tree_directly(tmp_path):
+    work = tmp_path / "work"
+    work.mkdir()
+    seen = {}
+    desc = {"run_tests": lambda where, t: (seen.setdefault("where", Path(where)), (True, "ok"))[1],
+            "timeout_s": 5}
+    AP._score(desc, work, 5)
+    assert seen["where"] == work
+
+
+def test_python_descriptor_scores_in_a_copy():
+    assert AP.LANG_DESCRIPTORS["python"].get("score_in_copy") is True

--- a/benchmarks/test_polyglot_metadata.py
+++ b/benchmarks/test_polyglot_metadata.py
@@ -1,0 +1,124 @@
+"""Scoring parameters, resume compatibility, exit code, turn accounting."""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import aider_polyglot as AP  # noqa: E402
+
+HARNESS = Path(__file__).parent / "aider_polyglot.py"
+
+
+def test_params_capture_what_changes_a_score():
+    d = AP.LANG_DESCRIPTORS["python"]
+    p = AP._scoring_params("m/x", "python", True, d)
+    for key in ("model", "language", "attempt_timeout_s", "test_timeout_s",
+                "retry", "score_in_copy", "allowed_tools", "env"):
+        assert key in p, key
+
+
+def test_attempt_timeout_comes_from_the_env_not_argparse():
+    """ATTEMPT_TIMEOUT_S is a module constant read at import; the guard must
+    compare against that, not an args field that does not exist."""
+    p = AP._scoring_params("m", "python", True, AP.LANG_DESCRIPTORS["python"])
+    assert p["attempt_timeout_s"] == AP.ATTEMPT_TIMEOUT_S
+
+
+@pytest.mark.parametrize("recorded,current,expected_count", [
+    ({"a": 1}, {"a": 1}, 0),
+    ({"a": 1}, {"a": 2}, 1),
+    ({}, {"a": 1}, 1),                      # nothing recorded == incompatible
+    ({"a": 1}, {"a": 1, "b": 2}, 1),        # a new parameter is a difference
+])
+def test_param_mismatches(recorded, current, expected_count):
+    assert len(AP._param_mismatches(recorded, current)) == expected_count
+
+
+@pytest.mark.parametrize("records,expected", [
+    ({}, 0),
+    ({"a": {"status": "pass_1"}}, 0),
+    ({"a": {"status": "fail"}}, 0),
+    ({"a": {"status": "fail_timeout"}}, 0),
+    ({"a": {"status": "empty_response"}}, 0),
+    ({"a": {"status": "error"}}, 1),
+    ({"a": {"status": "pass_1"}, "b": {"status": "error"}}, 1),
+])
+def test_exit_code_only_for_harness_errors(records, expected):
+    assert AP._exit_code(records) == expected
+
+
+def test_exit_code_ignores_records_this_run_did_not_write():
+    """A resumed run must not fail for an inherited error it never touched."""
+    inherited = {"old": {"status": "error"}}
+    written = {"new": {"status": "pass_1"}}
+    assert AP._exit_code(written) == 0
+    assert AP._exit_code({**inherited, **written}) == 1  # sanity: it does see errors
+
+
+def test_missing_exercise_dir_makes_the_process_exit_nonzero(tmp_path):
+    """End-to-end: a broken environment must not look like a finished 0% run."""
+    env = dict(os.environ, PYTHONPATH=str(HARNESS.parent))
+    r = subprocess.run(
+        [sys.executable, str(HARNESS), "--language", "python",
+         "--exercise", "definitely-not-an-exercise", "--model", "fake/model"],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+    assert r.returncode != 0, f"exited 0 despite a harness error\n{r.stdout}\n{r.stderr}"
+    assert "error" in (r.stdout + r.stderr).lower()
+
+
+class _CountingRpc:
+    """Fake agent whose attempts report distinct turn counts."""
+    turns = [3, 4]
+
+    def __init__(self, *a, **kw):
+        self.cwd = Path(kw["cwd"])
+        self.n = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def close(self):
+        pass
+
+    def prompt_and_collect(self, message, timeout=900):
+        n = self.n
+        self.n += 1
+
+        class R:
+            stop_reason = "agent_end"
+            agent_ended = True
+            turn_count = _CountingRpc.turns[n]
+            compaction_events = 0
+            assistant_text = "work"
+            tool_calls = [{"name": "read"}]
+        return R()
+
+
+def test_turn_count_sums_both_attempts_on_failure(tmp_path, monkeypatch):
+    """The old expression dropped r2.turn_count whenever the exercise failed,
+    so a two-attempt failure under-reported its own effort."""
+    src = tmp_path / "practice" / "ex"
+    src.mkdir(parents=True)
+    (src / "ex.py").write_text("stub")
+
+    monkeypatch.setitem(AP.LANG_DESCRIPTORS, "faker", {
+        "practice_dir": tmp_path / "practice",
+        "prepare": lambda s, w: (AP._copy_exercise(s, w), ([w / "ex.py"], []))[1],
+        "run_tests": lambda where, timeout: (False, "nope"),   # always fail -> retry
+        "syntax_hint": "",
+        "timeout_s": 5,
+    })
+    monkeypatch.setattr(AP, "PiRpc", _CountingRpc)
+    monkeypatch.setattr(AP, "LOG_ROOT", tmp_path / "logs")
+
+    rec = AP._run_exercise("faker", "ex", "fake/model", verbose=False, retry=True)
+    assert rec["status"] == "fail"
+    assert rec["turn_count"] == 7, f"expected 3+4, got {rec['turn_count']}"

--- a/benchmarks/test_rpc_terminal.py
+++ b/benchmarks/test_rpc_terminal.py
@@ -1,0 +1,103 @@
+"""Terminal-reason behaviour of PiRpc, driven by a fake pi subprocess.
+
+These cover the JSONL event loop, which the existing tests cannot: they spawn a
+real pi and skip when node_modules/.bin/pi is absent. EOF/deadline/crash need a
+process that exits on cue.
+"""
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rpc_client  # noqa: E402
+from rpc_client import PiRpc  # noqa: E402
+
+FAKE = Path(__file__).parent / "fake_pi.py"
+
+
+@pytest.fixture
+def fake_pi(monkeypatch):
+    """Point PiRpc at the fake instead of the real pi binary."""
+    monkeypatch.setattr(rpc_client, "PI_BIN", FAKE)
+    monkeypatch.setattr(rpc_client, "_extension_paths", lambda: [])
+    def _spawn(mode, cwd, **kw):
+        monkeypatch.setenv("FAKE_PI_MODE", mode)
+        return PiRpc(model="fake/model", cwd=str(cwd), **kw)
+    return _spawn
+
+
+def test_clean_run_reports_agent_end(fake_pi, tmp_path):
+    with fake_pi("clean", tmp_path) as rpc:
+        r = rpc.prompt_and_collect("go", timeout=30)
+    assert r.agent_ended is True
+    assert r.stop_reason == "agent_end"
+    assert r.tool_calls and r.tool_calls[0]["name"] == "read"
+    assert "hello" in r.assistant_text
+
+
+def test_crash_after_ack_is_process_exit_not_deadline(fake_pi, tmp_path):
+    """A pi that dies mid-run must not burn the whole budget or look like a timeout."""
+    with fake_pi("crash_after_ack", tmp_path) as rpc:
+        t0 = time.time()
+        r = rpc.prompt_and_collect("go", timeout=30)
+        elapsed = time.time() - t0
+    assert elapsed < 10, f"took {elapsed:.1f}s -- EOF did not wake the drain"
+    assert r.agent_ended is False
+    assert r.stop_reason == "process_exit"
+
+
+def test_hang_is_deadline(fake_pi, tmp_path):
+    with fake_pi("hang_after_ack", tmp_path) as rpc:
+        t0 = time.time()
+        r = rpc.prompt_and_collect("go", timeout=2)
+        elapsed = time.time() - t0
+    assert elapsed >= 2
+    assert r.agent_ended is False
+    assert r.stop_reason == "deadline"
+
+
+def test_agent_end_and_eof_together_still_agent_end(fake_pi, tmp_path):
+    """Ordering hazard: queue must be drained before the EOF flag is consulted."""
+    with fake_pi("end_then_exit", tmp_path) as rpc:
+        r = rpc.prompt_and_collect("go", timeout=30)
+    assert r.agent_ended is True
+    assert r.stop_reason == "agent_end"
+
+
+def test_exit_before_ack_raises_with_stderr(fake_pi, tmp_path):
+    with fake_pi("exit_before_ack", tmp_path) as rpc:
+        t0 = time.time()
+        with pytest.raises(rpc_client.PiProcessExited) as exc:
+            rpc.prompt_and_collect("go", timeout=30)
+        elapsed = time.time() - t0
+    assert elapsed < 10, f"took {elapsed:.1f}s -- did not notice the dead process"
+    assert "dying before ack" in str(exc.value)
+
+
+def test_stderr_is_complete_after_crash(fake_pi, tmp_path):
+    """gaia/tb/harbor read stderr exactly on failure; returning fast must not race it."""
+    with fake_pi("crash_after_ack", tmp_path) as rpc:
+        rpc.prompt_and_collect("go", timeout=30)
+        assert "boom" in rpc.stderr()
+
+
+def test_prompt_after_close_raises(fake_pi, tmp_path):
+    rpc = fake_pi("clean", tmp_path)
+    rpc.close()
+    with pytest.raises(RuntimeError):
+        rpc.prompt_and_collect("go", timeout=5)
+
+
+def test_close_is_idempotent(fake_pi, tmp_path):
+    rpc = fake_pi("clean", tmp_path)
+    rpc.close()
+    rpc.close()
+
+
+def test_promptresult_still_constructible_with_no_args():
+    r = rpc_client.PromptResult()
+    assert r.agent_ended is False
+    assert r.tool_calls == []


### PR DESCRIPTION
Eight commits fixing defects in the Polyglot benchmark harness, found by running it against a local model and then reviewing the fixes adversarially. Every one produces **wrong or non-comparable numbers rather than crashing**, so none are visible in normal use.

Reviewable commit-by-commit; each is independently revertable.

## The defects

| # | defect | effect |
|---|---|---|
| 1 | retry fired into a still-generating agent | **killed the whole run** at 4/15, discarding 11 exercises |
| 2 | `_run_exercise` unguarded in `main()` | one bad exercise discarded the rest |
| 3 | stdout EOF never woke the event drain | a crashed pi burned the full budget, indistinguishable from a timeout |
| 4 | tests ran in the agent's live worktree | scored a tree pi could still be writing to |
| 5 | empty completions classified as clean failures | **6 of 16** attempts; provider faults counted against the model |
| 6 | deterministic log dir never purged | stale artifacts from earlier runs read as current |
| 7 | both snapshots taken after the retry | attempt 1's artifact showed attempt 2's state |
| 8 | scoring parameters unrecorded | `--resume` blended incompatible runs into one uniform-looking file |
| 9 | exit 0 despite harness errors | a broken environment looked like a finished 0% run |
| 10 | `turn_count` dropped the retry's turns | two-attempt failures under-reported effort |

## Evidence

**#3** — measured with the new fake-pi fixture:

| case | before | after |
|---|---|---|
| crash after ack | 30 s, looked like a deadline | **0.03 s**, `process_exit` |
| exit before ack | 30 s `TimeoutError` | **0.03 s**, `PiProcessExited` + stderr |
| genuine hang | budget, indistinguishable | budget, `deadline` |

**#4** — instrumented three real exercises. pi had a **live child process at the exact moment tests would start**, in all three:

```
t+0.0s   pi_alive=True  children=['52268']
t+3.0s   pi_alive=True  children=[]
```

They happened not to write; the window is real regardless. Tests now run against a copy, which removes the race on every path instead of only the one reasoned about. pi has no cancel RPC, so stopping the agent instead would break the retry.

**#6** — in a real log tree, `connect/trajectory_2.json` was **two hours older** than the `trajectory_1.json` beside it. Comparing such a pair as if it were one run produced a confident, wrong conclusion during review of this series.

## Notes for review

- **`_was_clock_capped` was deleted, not tuned.** Inferring "capped by the clock" from elapsed time cannot work once #3 is understood: a crash consumes the budget too.
- **`stop_reason` is read through a shim.** With `rpc_client.py` reverted to pristine, all 48 harness tests still pass — scoring degrades to the old signal rather than breaking.
- **Resume warns, it does not refuse.** `docs/benchmark-qwen3.6-35b-a3b.md` records the canonical run deliberately changing a scoring parameter mid-run and resuming; refusing would have blocked it. Every record now carries its own parameters, so a mixed file stays analysable.
- **`empty_response` is a new status**, distinct from `fail`.
- **Default behaviour is unchanged** on the happy path: attempts that complete normally still retry, so `pass_2` results stay comparable to published runs. `ATTEMPT_TIMEOUT_S` defaults to the existing 900.

## Tests

**57 passing, needing neither the pi CLI nor a model server.** That mattered: the 4 existing tests self-skip without `node_modules/.bin/pi`, and CI ran only `npm ci` — so **none of them executed anywhere**. Adds a `pytest` CI job.

Each fix was **mutation tested** — the defect reintroduced to confirm the suite fails. That found a real gap: nothing asserted `_attempt_outcome` consults `_is_empty_response`, so deleting that branch left all 22 tests green. Fixed.
